### PR TITLE
Add documentation on index dates

### DIFF
--- a/study_definition.md
+++ b/study_definition.md
@@ -497,6 +497,47 @@ There is also a custom distribution matching a typical population-age distributi
         },
     ),
 ```
+
+# Index Dates
+
+If you define an `index_date` on a study definition then everywhere that you might normally supply a date you can now supply a "date expression". Here is a simple example:
+
+```py
+study = StudyDefinition(
+    index_date="2015-06-01",
+    population=patients.with_these_clinical_events(
+        copd_codes,
+        between=[
+            "first_day_of_year(index_date) - 2 years",
+            "last_day_of_year(index_date)",
+        ],
+    ),
+    age=patients.age_as_of("index_date"),
+)
+```
+
+This can make it easier to change the index date of a study by making sure it is only defined in once place.
+
+The simplest date expression is just the string `index_date`, which gets replaced by whatever the index date is set to.
+
+It's also possible to apply various functions to the index date. The available options (hopefully self-explanatory) are:
+```
+first_day_of_month(index_date)
+last_day_of_month(index_date)
+first_day_of_year(index_date)
+last_day_of_year(index_date) 
+```
+
+Finally, intervals of time can be added or subtracted from the index date (or from a function applied to the index date). The available units are `year(s)`, `month(s)` and `day(s)`. For example:
+```
+index_date + 90 days
+first_day_of_month(index_date) + 9 months
+index_date - 1 year
+```
+
+Note that if the index date is 29 February and you add or subtract some number of years which doesn't lead to a leap year, then an error will be thrown. Similarly, if adding or subtracting months leads to a month with no equivalent day e.g. adding 1 month to 31 January to produce 31 February. 
+
+
 ## Flowcharts (temporary workaround)
 
 Many studies will require a flowchart to show inclusion/exclusion of patients in the study. Eventually the numbers of patients excluded/included will be summarised automatically following cohort extract, but for now, a slightly manual approach is required:


### PR DESCRIPTION
These were added in this PR here: https://github.com/opensafely/cohort-extractor/pull/255

The main reason for adding them is to support extracting data for measures in the aftershocks project. It means that the same study definition can be run with the index date set to successive months in order to generate monthly timeseries data.