### PR TITLE
Document Requesting Futher R Dependencies

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,1 @@
-3.8.1/envs/documentation
+3.8.1

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ As such there are some pre-requisites that collaborators must satisfy to use the
 
 ### Essential
 * **Stata, R or Python**
-OpenSAFELY currently supports Stata v16.1, Python 3.8, and R 4.0 for statistical analysis. Available libraries are restricted by the framework (documentation to follow)
+OpenSAFELY currently supports Stata v16.1, Python 3.8, and [R 4.0](working-with-r.md) for statistical analysis. Available libraries are restricted by the framework (documentation to follow)
 * **Git**
 The workflow is strongly integrated into Git/GitHub.
 At a minimum you need to be able to clone a remote git repository, create a branch to work on, commit changes to it, push those changes to the remote repository, and create a pull request.

--- a/docs/working-with-r.md
+++ b/docs/working-with-r.md
@@ -1,0 +1,8 @@
+# Working with R
+The OpenSAFELY R Image ships with a [given set of packages](https://github.com/opensafely/r-docker/blob/master/Dockerfile) baked in.
+
+## Requesting Extra Packages
+* Make an issue in https://github.com/opensafely/r-docker/issues
+* Explain the rationale
+* Get another member of the suppoRt group to chip in on the issue (e.g. do they agree; do they think a different package might do the same thing better)
+* Assign to Simon when discussion finished

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,11 +2,8 @@ site_name: OpenSAFELY documentation
 nav:
     - Introduction: index.md
     - Updating the Documentation: updating-documentation.md
-    
     - Our Philosophy:
         - Open Working Methods: open-methods.md
-        
-        
     - Data sources: dataset-landing-page.md
     - Getting started:
         - Overview: getting-started.md
@@ -53,6 +50,7 @@ nav:
         - Code Reviews: code-reviews.md
     - First-time walkthrough: onboarding_analysts.md
     - Code of conduct: code-of-conduct.md
+    - Working with R: working-with-r.md
 
 
 theme: material


### PR DESCRIPTION
This adds a page, "Working with R", to document the process for requesting more dependencies in our R image.

I've used the name "Working with R" on the basis that further R specific docs can go in there and we can have matching Python and Stata pages. 

Is there a better place in the nav for this to live?

Fixes #43 