### PR TITLE
Remove type column

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ plugins:
                 show_source: false
                 show_if_no_docstring: true
                 heading_level: 4
+        custom_templates: templates
 
 markdown_extensions:
     - pymdownx.snippets:

--- a/templates/python/material/parameters.html
+++ b/templates/python/material/parameters.html
@@ -1,0 +1,21 @@
+<p><strong>Parameters:</strong></p>
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Type</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for parameter in parameters %}
+      <tr>
+        <td><code>{{ parameter.name }}</code></td>
+        <td><code>{{ parameter.annotation }}</code></td>
+        <td>{{ parameter.description|convert_markdown }}</td>
+        <td>{% if parameter.default %}<code>{{ parameter.default }}</code>{% else %}<em>required</em>{% endif %}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/templates/python/material/parameters.html
+++ b/templates/python/material/parameters.html
@@ -3,7 +3,6 @@
   <thead>
     <tr>
       <th>Name</th>
-      <th>Type</th>
       <th>Description</th>
       <th>Default</th>
     </tr>
@@ -12,7 +11,6 @@
     {% for parameter in parameters %}
       <tr>
         <td><code>{{ parameter.name }}</code></td>
-        <td><code>{{ parameter.annotation }}</code></td>
         <td>{{ parameter.description|convert_markdown }}</td>
         <td>{% if parameter.default %}<code>{{ parameter.default }}</code>{% else %}<em>required</em>{% endif %}</td>
       </tr>


### PR DESCRIPTION
This removes the empty type column from the tables of parameters.

Before:

![image](https://user-images.githubusercontent.com/28734/102086796-8cf1fc80-3e10-11eb-9f44-88673048ec3b.png)

After:

![image](https://user-images.githubusercontent.com/28734/102086834-99765500-3e10-11eb-88f3-5fb0df724da2.png)
