### PR TITLE
Fix url for create-repository-owner.png

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -111,7 +111,7 @@ you through the process of creating an account, if you don't already have one.
    ![image](images/use-this-template-button.png)
 4. Use the **Owner** drop-down menu, and select the account you want to own the
    repository (typically under your own account)
-   ![image](create-repository-owner.png)
+   ![image](images/create-repository-owner.png)
 5. Type a name for your repository, and an optional description.
    ![image](images/create-repository-name.png)
 6. Choose a repository visibility.  This would usually be "Public".


### PR DESCRIPTION
* was not displaying on live site
<img width="1503" alt="Screenshot 2021-03-31 at 12 36 44" src="https://user-images.githubusercontent.com/2082895/113138543-d3336600-921d-11eb-85e4-bbe3d8397f63.png">
