### PR TITLE
Explain force run

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -216,7 +216,7 @@ between these two dates*"; lines 14-15 "*Give me a column of data corresponding
 to the age of each patient on the given date*"; and lines 16-18 "*I expect
 every patient to have a value, and the distribution of ages to match that of the
 real UK population*"
-1. In an Anaconda Prompt, run `opensafely run run_all --force`. A new file will
+1. In an Anaconda Prompt, run `opensafely run run_all --force-run-dependencies`. A new file will
    be created in the folder `output/input.csv`. Open that file (using Visual
    Studio Code, or Excel) and you'll see it now contains an age for 1000
    randomly generated patients.
@@ -275,7 +275,7 @@ the action creates. Line 17 says that the items indented below it are
 *moderately* sensitive, that is they may be released to the public after a
 careful review (and possible redaction). Line 18 says that there's one output
 file, which will be found at `output/descriptive.png`.
-5. Type `opensafely run run_all --force`. This should end by telling you a file
+5. Type `opensafely run run_all --force-run-dependencies`. This should end by telling you a file
    containing the histogram has been created. Open it, and check it looks right.
 
 ## 4. Push your study to github, and watch the automated tests pass

--- a/docs/opensafely-cli.md
+++ b/docs/opensafely-cli.md
@@ -55,6 +55,42 @@ opensafely run make_graph
 
 will run the `make_graph` action.
 
+<details markdown="1">
+<summary>To run or to force run?</summary>
+
+The `run` command takes `--force-run-dependencies` or `-f` arguments,
+where the latter is the short form of the former.
+However, what do these arguments do?
+
+When an action is a dependency of another action,
+the `run` command uses the dependency action's outputs
+-- and one of these arguments, if one is present --
+to determine whether the dependency action should also run.
+
+If you specify the action to run but don't pass one of these arguments, then:
+
+* The action is run, whether or not its outputs exist.
+* Its dependencies are also run, if their outputs do not exist.
+  Conversely, its dependencies are not run, if their outputs exist.
+
+If you specify the action to run and pass one of these arguments, then:
+
+* The action is run, whether or not its outputs exist.
+* Its dependencies are also run, whether or not their outputs exist.
+
+What about the `run_all` action?
+Think of all actions as dependencies of the `run_all` action.
+
+If you specify the `run_all` action but don't pass one of these arguments,
+then for each action:
+
+* If the action's outputs exist, then it is not run.
+* If the action's outputs do not exist, then it is run.
+
+If you specify the `run_all` action and pass one of these arguments, then:
+
+* All actions are run, whether or not their outputs exist.
+</details>
 
 ### `codelists`
 This command is for working with codelists. 


### PR DESCRIPTION
Two commits, which hopefully explain the force run argument. I'm going to assume that as it was helpful to me to write this explanation, then it will be helpful to other people to read it 🙂 

A couple of things tripped me up, when walking this path. The first was that the Getting Started Guide used `--force`. I *think* argparse expands this silently, but I took it that the action itself was forced as well as its dependencies. The second was that I didn't realize that specifying an action always runs that action. Again, because of the first trip up, I took it that specifying an action without the argument was a no-op.

Thanks @bloodearnest for talking this through, today.