### PR TITLE
Suggest using main/master as the default branch for a new workspace

### DIFF
--- a/docs/job-server.md
+++ b/docs/job-server.md
@@ -9,7 +9,7 @@ To submit job-requests (i.e., to run one or more actions), the general process i
 	* click the `Add a New WorkSpace` button
 	* choose a name, for example the name of the repo
 	* select a database to run against: either the full database, or a ~20% sample of it (sampling is based on an arbitrary selection of practices and not guaranteed to be representative)
-	* select the repo and branch whose action you want to run
+	* select the repo and branch whose action you want to run (in most cases, the branch will be either `main` or `master`)
 	* click `Submit`.
 *  **Select actions** to run:
 	* select the actions you want to run by clicking the `Run` buttons

--- a/docs/job-server.md
+++ b/docs/job-server.md
@@ -4,7 +4,7 @@ To run code for real in the production environment, use the [https://jobs.opensa
 Here you can see (even without a login) all the ongoing projects within OpenSAFELY, and the specific _jobs_ that have been run on the server.
 To submit job-requests (i.e., to run one or more actions), the general process is as follows:
 
-*  **Log in** using your GitHub credentials (this should happen automatically if you have access to the OpenSAFELY GitHub organisation).
+* **Log in** using your GitHub credentials (this should happen automatically if you have access to the OpenSAFELY GitHub organisation).
 * **Create a workspace** (or select an existing workspace):
 	* click the `Add a New WorkSpace` button
 	* choose a name, for example the name of the repo


### PR DESCRIPTION
Suggest using `main`/`master` as the default branch for a new workspace. This seems to be the convention, when looking at existing workspaces on job-server. It also seems to be the intention, given a comment by @sebbacon on opensafely-core/job-runner#196.

I opted for `main`/`master` rather than simply `main` because at present the research template uses `master` which, at some point, GH suggests renaming to `main`. For more information, see opensafely/research-template#32.