### PR TITLE
Correct a link for the macOS install guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ forum](https://github.com/opensafely/documentation/discussions)!
 !!! note "Windows-only!"
     This version of the tutorial is aimed at Windows users.
     Mac users should be able to follow along as well, with a few
-    hopefully-obvious alterations; see also the [macOS Install Guide](docs/install-macos.md)!
+    hopefully-obvious alterations; see also the [macOS Install Guide](install-macos.md)!
 
 
 ## Motivation


### PR DESCRIPTION
From the Getting Started page. This might be a frustration for Mac
users, particularly as the much less obvious alternative route for the
Mac instructions is to click multiple times through the sidebar.

This was flagged by `mkdocs build --strict`.