### PR TITLE
Document the with_these_decision_support_values function

### DIFF
--- a/docs/study-def-variables.md
+++ b/docs/study-def-variables.md
@@ -68,6 +68,9 @@ These variables are derived from data held in the patients' primary care records
 ::: cohortextractor.patients.household_as_of
 &nbsp;
 
+::: cohortextractor.patients.with_these_decision_support_values
+&nbsp;
+
 ## ICNARC
 These variables are derived from the Intensive Care National Audit and Research Centre Case-Mix Programme (ICNARC-CMP), which collects information on ICU admissions across England.
 For more information, see the [ICNARC data section](dataset-icnarc.md).

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,7 @@ numpy==1.19.2
     #   pyarrow
     #   scipy
     #   seaborn
-opensafely-cohort-extractor==1.30.0
+opensafely-cohort-extractor==1.31.0
     # via -r requirements.in
 opensafely-jobrunner==2.1.6
     # via opensafely-cohort-extractor


### PR DESCRIPTION
This function was introduced by opensafely-core/cohort-extractor#549, which closes opensafely-core/cohort-extractor#535.