### PR TITLE
Update cohortextractor to v1.34.0

### DIFF
--- a/docs/study-def-variables.md
+++ b/docs/study-def-variables.md
@@ -133,6 +133,12 @@ These variables are derived from the Secondary Uses Services (SUS) data, and the
 &nbsp;
 
 
+## NHS England COVID-19 data store
+(Documentation on the source of this data will be forthcoming later.)
+
+:::cohortextractor.patients.with_healthcare_worker_flag_on_covid_vaccine_record
+
+
 ## Utility functions
 
 These variables create new variable from existing variables. They do not extract any data directly.

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,7 @@ numpy==1.19.2
     #   pyarrow
     #   scipy
     #   seaborn
-opensafely-cohort-extractor==1.32.0
+opensafely-cohort-extractor==1.34.0
     # via -r requirements.in
 opensafely-jobrunner==2.1.6
     # via opensafely-cohort-extractor
@@ -89,6 +89,8 @@ presto-python-client==0.7.0
     # via opensafely-cohort-extractor
 prettytable==2.0.0
     # via opensafely-cohort-extractor
+py4j==0.10.9
+    # via pyspark
 py==1.10.0
     # via retry
 pyarrow==4.0.0
@@ -105,6 +107,8 @@ pyopenssl==20.0.1
     # via requests-pkcs12
 pyparsing==2.4.7
     # via matplotlib
+pyspark==3.1.2
+    # via opensafely-cohort-extractor
 python-dateutil==2.8.1
     # via
     #   matplotlib


### PR DESCRIPTION
Building the documentation now involves installing a 212MB pyspark package, which makes me a bit sad but shouldn't be an issue in practice I hope.