### PR TITLE
Fix sidebar menu colour at smaller screen sizes

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -36,7 +36,7 @@ body {
   color: var(--colorOffBlack);
   font-family: "Public Sans", -apple-system, BlinkMacSystemFont, "Segoe UI",
     Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-    letter-spacing:-0.02em;
+  letter-spacing: -0.02em;
   -webkit-font-smoothing: unset;
   -moz-osx-font-smoothing: unset;
 }
@@ -149,4 +149,12 @@ body {
 
 .md-typeset .warning > .admonition-title::before {
   background-color: var(--colorWarning);
+}
+
+.md-nav--secondary {
+  background-color: transparent;
+}
+
+.md-nav--secondary .md-nav {
+  background-color: transparent;
 }


### PR DESCRIPTION
## Before

<img width="1298" alt="Screenshot 2021-06-21 at 10 53 55" src="https://user-images.githubusercontent.com/24863179/122743600-09154300-d27f-11eb-8f2a-7c85589d063d.png">

## After

<img width="1298" alt="Screenshot 2021-06-21 at 10 54 07" src="https://user-images.githubusercontent.com/24863179/122743615-0b779d00-d27f-11eb-8dca-95ed62af4451.png">
