### PR TITLE
Switch Branch Reference to Main

### DIFF
--- a/docs/code-reviews.md
+++ b/docs/code-reviews.md
@@ -27,7 +27,7 @@ your request to aid the reviewer.
 ## When to ask for code review?
 
 Code reviews should be the default. A good way of conceptualising when to ask for a review is to think about commits and branches. All your work should be done in branches and you should aim to 
-merge your branches frequently. A user makes a branch to change a feature or adding some new analysis and make several commits to the new branch. When the time comes to merge this back to master, there is a natural inflexion point to do a code review, and each merge should be 
+merge your branches frequently. A user makes a branch to change a feature or adding some new analysis and make several commits to the new branch. When the time comes to merge this back to main, there is a natural inflexion point to do a code review, and each merge should be 
 accompanied with a code review. If you are in a hurry, and no-one has time to do a more thorough 
 code review, bear in mind that even a cursory code review is better than no code review. 
 

--- a/docs/codelist-creation.md
+++ b/docs/codelist-creation.md
@@ -73,7 +73,7 @@ Once a draft codelist has been agreed, it must be signed-off by a "data expert" 
 * Go to the OpenCodelists [new codelist page](https://www.opencodelists.org/codelist/opensafely/).
 You will need an editor account. Ask one of the tech team for one if you do not have one.
 * Fill in the fields. Include lots of detail (specific guidance to follow).
-    * **CSV data**: [Export your Spreadsheet to a CSV](https://github.com/opensafely/documentation/blob/master/codelist%20creation.md#exporting-a-csv-from-a-spreadsheet) and choose that file.
+    * **CSV data**: [Export your Spreadsheet to a CSV](#exporting-a-csv-from-a-spreadsheet) and choose that file.
     * **References**: this should include a link to the issue on the [codelist-development repo](https://github.com/opensafely/codelist-development), and any other relevant materials.
     * **Sign Off**: This should match the people signing off on the issue. You need at least 2 people and can have many more.
 * Click Submit and check the new codelist has appeared on the main site.

--- a/docs/codelist-snomed.md
+++ b/docs/codelist-snomed.md
@@ -2,7 +2,7 @@
 
 At the time of writing (26 Oct 2020), most SNOMED CT Codelists on [OpenCodelists](https://www.opencodelists.org/)
 have been generated from CTV3 Codelists using 
-a [mapper function](https://github.com/opensafely/opencodelists/blob/master/mappings/ctv3sctmap2/mappers.py).
+a [mapper function](https://github.com/opensafely/opencodelists/blob/main/mappings/ctv3sctmap2/mappers.py).
 They have not been reviewed, or used in any research. They are clearly marked with 
 "Automatically-generated equivalent" within the description. 
 

--- a/docs/requests-documentation.md
+++ b/docs/requests-documentation.md
@@ -4,9 +4,9 @@ please do! You can either:
 
 * Suggest improvements in an [issue](https://github.com/opensafely/documentation/issues).
 * Clone [the repo](https://github.com/opensafely/documentation) locally, make edits on a new branch, then create a pull request for it.
-* [Edit directly on GitHub](https://github.com/opensafely/documentation/tree/master/docs) ([instructions](https://docs.github.com/en/github/managing-files-in-a-repository/editing-files-in-your-repository)), making sure to "Create a new branch for this commit and start a pull request".
+* [Edit directly on GitHub](https://github.com/opensafely/documentation/tree/main/docs) ([instructions](https://docs.github.com/en/github/managing-files-in-a-repository/editing-files-in-your-repository)), making sure to "Create a new branch for this commit and start a pull request".
 
-Do not commit changes directly to the master branch.
+Do not commit changes directly to the main branch.
 
 ## Making changes to the study definition variables
 
@@ -21,7 +21,7 @@ This ensures that a new version of `cohortextractor` is released and can be impo
 Then add a reference to your new variable in the [variables page](study-def-variables.md).
 
 Additionally, the
-[`requirements.txt`](https://github.com/opensafely/documentation/blob/master/requirements.txt)
+[`requirements.txt`](https://github.com/opensafely/documentation/blob/main/requirements.txt)
 file in the [documentation
 repo](https://github.com/opensafely/documentation) itself has to be
 updated to match the new incremented version of `cohortextractor`. See


### PR DESCRIPTION
This updates various references to the old `master` branch to `main`, it's mostly selective `s/master/main`.