### PR TITLE
Removal of backtick end of line 489

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -486,7 +486,7 @@ real UK population*"
    the CSV file to be created again.
 
    ```
-   $ opensafely run run_all --force-run-dependencies`
+   $ opensafely run run_all --force-run-dependencies
    ```
 
    A new `input.csv` file will be created in the `output` folder. Open that


### PR DESCRIPTION
Minor improvement to getting started tutorial, suggesting the removal the backtick at the end of $ opensafely run run_all --force-run-dependencies.