### PR TITLE
Fix macOS Install Instructions

### DIFF
--- a/docs/install-macos.md
+++ b/docs/install-macos.md
@@ -20,6 +20,18 @@ Once homebrew is installed use it to install [pipx](https://pipxproject.github.i
 brew install pipx pyenv
 ```
 
+Add pipx to your path with:
+
+```bash
+echo 'export PATH="$HOME/.local/bin/:$PATH"' >> ~/.bashrc
+```
+
+and reload your shell environment with:
+
+```bash
+source ~/.bashrc
+```
+
 Next, install [Docker for Mac](https://docs.docker.com/docker-for-mac/install/), [GitHub Desktop](https://desktop.github.com/), and [Visual Studio Code](https://code.visualstudio.com/):
 
 ```bash


### PR DESCRIPTION
`pipx` installs libraries into their own venvs, exposing their binaries in `~/.local/bin`, but we still need to put that on the $PATH.  We've opted to take this route instead of `pipx run <tool>` to avoid tying ourselves to pipx across multiple platforms.

Fixes #280 