### PR TITLE
clarify that --output_dir for generate_measures also defines the input directory

### DIFF
--- a/docs/measures.md
+++ b/docs/measures.md
@@ -170,7 +170,7 @@ This will prevent it from recalculating the measure for any months or weeks whic
 However the final step, which combines output across time periods, will always be run.
 
 This command accepts an `--output-dir` argument, which defines the directory in which the output measure files will be created. 
-If this is configured, the command will also look for the input files in this directory, and so both this and the generate_cohort command in step 2 must be configured identically.
+If the `--output-dir` argument is configured, `generate_measures` expects the input cohort files to also be in the output directory. To ensure this, include the same `--output-dir` argument in the previous `generate_cohort` step.
 
 ## Putting it all together in a pipeline
 

--- a/docs/measures.md
+++ b/docs/measures.md
@@ -169,6 +169,9 @@ This command also respects the `--skip-existing` flag.
 This will prevent it from recalculating the measure for any months or weeks which have already been calculated.
 However the final step, which combines output across time periods, will always be run.
 
+This command accepts an `--output-dir` argument, which defines the directory in which the output measure files will be created. 
+If this is configured, the command will also look for the input files in this directory, and so both this and the generate_cohort command in step 2 must be configured identically.
+
 ## Putting it all together in a pipeline
 
 To generate the final outputs `measure_hosp_admission_by_stp.csv` and `measure_death_by_stp.csv` in a project pipeline, you would use the following actions:


### PR DESCRIPTION
If either the generate_cohort or generate_measures steps have an --output_dir defined, then they both must have this configured identally for generate_measures to pick up the files. I've tried my best to clarify this in a couple of sentences.