### PR TITLE
Describe New Releasing Process

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -50,3 +50,5 @@ For releasing outputs we have some additional roles:
 **OutputPublisher:**
 
 * Confirm publication of outputs
+
+---8<-- 'includes/glossary.md'

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -29,6 +29,12 @@ Additionally, users with the **ProjectCoordinator** role can:
 
 ## Releasing Outputs
 
+!!! note
+    Releasing of outputs to the job server is currently being rolled out.
+    See [team manual](https://bennettinstitute-team-manual.pages.dev/tech-team/releasing-outputs/) for instructions on setting up a user.
+    The new release process is described separately in [Google Docs](https://docs.google.com/document/d/1PSzMoCFov2olJpxrFGT1DccWUqGDA67mUvPIyIhOcew/edit#heading=h.aokkzsfuxo4n).
+
+
 For releasing outputs we have some additional roles:
 
 **ProjectCollaborator:**

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -31,7 +31,7 @@ Additionally, users with the **ProjectCoordinator** role can:
 
 !!! note
     Releasing of outputs to the job server is currently being rolled out.
-    See [team manual](https://bennettinstitute-team-manual.pages.dev/tech-team/releasing-outputs/) for instructions on setting up a user.
+    See [team manual](https://bennettinstitute-team-manual.pages.dev/tech-team/playbooks/job-server-releasing-outputs/) for instructions on setting up a user.
     The new release process is described separately in [Google Docs](https://docs.google.com/document/d/1PSzMoCFov2olJpxrFGT1DccWUqGDA67mUvPIyIhOcew/edit#heading=h.aokkzsfuxo4n).
 
 

--- a/includes/glossary.md
+++ b/includes/glossary.md
@@ -33,3 +33,5 @@
 *[CLI]: Command-line interface, a text interface used by some computer software that is usually run via a "terminal" or "command-line shell".
 *[2FA]: Two-factor authentication, a means of verifying a user is authorised to access a service by checking for something that only the user should know (e.g. a password) and something the user should have (e.g. an authenticator application installed on the user's phone).
 *[API]: Application Programming Interface. An agreed way for one system to communicate with another system.
+*[released outputs]: files from Level 4 uploaded to the Jobs site.
+*[draft published outputs]: a collection of released outputs prepared for publication to the general public.


### PR DESCRIPTION
This adds some context on the new release process and links the glossary to the permissions page so we can define some terms for releasing outputs.

Fixes #371 