### PR TITLE
Restructure menu

### DIFF
--- a/docs/dataset-intro.md
+++ b/docs/dataset-intro.md
@@ -2,12 +2,14 @@ This section provides contextual information on the core primary care EHR system
 
 Use the navigation pane to the left of the page view information on each dataset.
 
-## Primary care data explainer
-We've made a video to help explain primary care data in more detail; essential viewing if you're new to this domain.
+
+## What is primary care data?
+The core patient-level data used within OpenSAFELY is based on electronic GP records that are collected and securely stored to facilitate patient management by healthcare providers. They capture symptoms, test results, diagnoses, prescriptions, onward referrals, demographic and social characteristics, and so on. Essentially, everything about a patient that is electronically recorded or accessed by GPs. 
+
+GP records, or primary care records, can also be used for conducting health research, which is what OpenSAFELY was built for. We've made a video to help explain primary care data in more detail; essential viewing if you're new to this domain.
 
 <div class="video-wrapper">
   <iframe width="1280" height="720" src="https://www.youtube.com/embed/NEwSQ5-dWSg" frameborder="0" allowfullscreen></iframe>
 </div>
-
 
 ---8<-- 'includes/glossary.md'

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,9 +61,9 @@ In this guide, we've documented two different ways to work with OpenSAFELY:
      * you want to have more control on the tools you use to develop
        studies for OpenSAFELY.
 
-    The current local installation guide is aimed at Windows
-    users. Mac users should be able to follow along as well, with a few
-    hopefully-obvious alterations; see also the [macOS Install
+    The [current local installation guide](install-intro.md) is aimed at
+    Windows users. Mac users should be able to follow along as well, with
+    a few hopefully-obvious alterations; see also the [macOS Install
     Guide](install-macos.md)! We aim to integrate macOS instructions
     into this guide in future.
 

--- a/docs/good-practice-intro.md
+++ b/docs/good-practice-intro.md
@@ -1,6 +1,0 @@
-!!! note "These documents are a work-in-progress"
-    This section will contain information on the core primary care EHR on which OpenSAFELY in based, as well as all external datasets imported to the secure EHR environment.
-
-
-
----8<-- 'includes/glossary.md'

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ## What is OpenSAFELY?
 
-OpenSAFELY is a secure analytics platform for electronic health records in the NHS, created to deliver urgent results during the global COVID-19 emergency.
+[OpenSAFELY](https://www.opensafely.org/) is a secure analytics platform for electronic health records in the NHS, created to deliver urgent results during the global COVID-19 emergency.
 It is now successfully delivering analyses across more than 57 million patients' full pseudonymised primary care NHS records, with more to follow shortly.
 
 All our analytic software is open for security review, scientific review, and re-use.
@@ -60,7 +60,7 @@ The [Analysis workflow](workflow) gives a high-level view of the steps involved 
 See our [installation](install-intro.md) pages for complete installation
 instructions if you wish to install on your own computer.
 
-When you are more comfortable with how OpenSAFELY works, We recommend following one of our OpenSAFELY walkthroughs (see [this notebook](https://github.com/opensafely/os-demo-research#opensafely-demo-materials)) to guide you through the platform workflow on your own computer with dummy data, rather than using the documentation pages alone.
+When you are more comfortable with how OpenSAFELY works, we recommend following one of our OpenSAFELY walkthroughs (see [this notebook](https://github.com/opensafely/os-demo-research#opensafely-demo-materials)) to guide you through the platform workflow on your own computer with dummy data, rather than using the documentation pages alone.
 
 !!! note "These documents are a work-in-progress"
     Please see the [Updating the Documentation page](requests-documentation.md) if you want to make improvements.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,7 @@ nav:
           - The project pipeline: actions-pipelines.md
       - Job server: job-server.md
       - Release files from the server: releasing-files.md
-      - Permissions in OpenSAFELY: permissions.md
+      - Permissions: permissions.md
   - OpenSAFELY best practice:
       - Overview: good-practice-intro.md
       - The DataLab Open Manifesto: open-data-manifesto.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,16 +2,24 @@ site_name: OpenSAFELY documentation
 repo_url: https://github.com/opensafely/documentation
 nav:
   - Introduction: index.md
-  - How OpenSAFELY works:
+  - About OpenSAFELY:
       - Our philosophy: open-methods.md
       - Security: security-levels.md
-      - Analysis workflow: workflow.md
+      - Data sources:
+          - Overview: dataset-intro.md
+          - SystmOne primary care: dataset-systmone.md
+          - EMIS primary care: dataset-emis.md
+          - Externally linked data:
+              - Covid-19 test results: dataset-sgsscovid.md
+              - Emergency attendances: dataset-ecds.md
+              - Hospital admissions: dataset-apc.md
+              - Intensive care admissions (covid-19 only): dataset-icnarc.md
+              - In-hospital deaths (covid-19 only): dataset-cpns.md
+              - Registered deaths: dataset-onsdeaths.md
   - Getting Started guide: getting-started.md
-
-  - How-to guides:
-      - Create inclusion/exclusion flowcharts: study-def-flowcharts.md
-      - Release files from the server: releasing-files.md
-  - Reference:
+  - Using OpenSAFELY:
+      - Analysis workflow: workflow.md
+      - GitHub repository layout: repositories.md
       - Detailed installation guides:
           - Overview: install-intro.md
           - Managing Gitpod workspaces: gitpod-workspaces.md
@@ -20,7 +28,6 @@ nav:
           - Docker: install-docker.md
           - OpenSAFELY CLI: opensafely-cli.md
           - macOS: install-macos.md
-      - GitHub repository layout: repositories.md
       - Study definitions:
           - Overview: study-def.md
           - Working with dates: study-def-dates.md
@@ -28,6 +35,7 @@ nav:
           - Dummy data and expectations: study-def-expectations.md
           - Variable reference: study-def-variables.md
           - Measures: measures.md
+          - Create inclusion/exclusion flowcharts: study-def-flowcharts.md
           - Programming tricks: study-def-tricks.md
       - Codelists:
           - Introduction to codelists: codelist-intro.md
@@ -41,30 +49,20 @@ nav:
           - The `cohortextractor` action: actions-cohortextractor.md
           - The project pipeline: actions-pipelines.md
       - Job server: job-server.md
-      - Data sources:
-          - Overview: dataset-intro.md
-          - SystmOne primary care: dataset-systmone.md
-          - EMIS primary care: dataset-emis.md
-          - Externally linked data:
-              - Covid-19 test results: dataset-sgsscovid.md
-              - Emergency attendances: dataset-ecds.md
-              - Hospital admissions: dataset-apc.md
-              - Intensive care admissions (covid-19 only): dataset-icnarc.md
-              - In-hospital deaths (covid-19 only): dataset-cpns.md
-              - Registered deaths: dataset-onsdeaths.md
+      - Release files from the server: releasing-files.md
       - Permissions in OpenSAFELY: permissions.md
-  - Good practice:
+  - OpenSAFELY best practice:
       - Overview: good-practice-intro.md
       - The DataLab Open Manifesto: open-data-manifesto.md
+      - Publishing your GitHub Repository: publishing-repo.md
       - Developing a protocol: protocol.md
       - Using Git effectively: git-workflow.md
       - Code reviews: code-reviews.md
-      - Publishing your GitHub Repository: publishing-repo.md
-  - Support:
+  - Requesting changes:
       - Overview: requests-intro.md
       - Requesting new libraries: requests-packages.md
       - Requesting study definition variables: requests-variables.md
-  - Updating the documentation: requests-documentation.md
+      - Updating the documentation: requests-documentation.md
   - Platform News: news.md
 
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,7 +52,6 @@ nav:
       - Release files from the server: releasing-files.md
       - Permissions: permissions.md
   - OpenSAFELY best practice:
-      - Overview: good-practice-intro.md
       - The DataLab Open Manifesto: open-data-manifesto.md
       - Publishing your GitHub Repository: publishing-repo.md
       - Developing a protocol: protocol.md


### PR DESCRIPTION
Should create a more logical structure with fewer high-level menu items, hopefully easier to navigate. We should ensure that the "best practices" sections are referenced elsewhere to help users find them. Some sections/intros might need rewording to fit with the new structure.