### PR TITLE
More on csv.gz format

### DIFF
--- a/docs/actions-cohortextractor.md
+++ b/docs/actions-cohortextractor.md
@@ -56,15 +56,15 @@ A basic `generate_cohort` action looks like this:
 
 ```yaml
 generate_study_cohort
-  run: cohortextractor:latest generate_cohort --output-format =csv.gz
+  run: cohortextractor:latest generate_cohort --output-format=csv.gz
   outputs:
     highly_sensitive:
       data: output/input.csv.gz
-    ### This file is produced in compressed format. If using Stata for your analysis you may need to remove 
-    ### the --output-format option and the .gz file extension to produce an uncompressed CSV instead.
+    ### This file is produced in compressed format. If using Stata for your analysis you may need to change
+    ### the --output-format option to 'csv' and the .gz file extension to produce an uncompressed CSV instead.
 ```
 
-This produces a zipped file to reduce storage space required in the backend. Missing the `--output-format=csv.gz` argument allows an uncompressed CSV to be produced which may be useful while testing in dummy data or if using Stata for analysis of this file. To import the compressed file in Python, you can use `pd.read_csv(<file>, compression='gzip')`. 
+This produces a zipped file to reduce storage space required in the backend. Changing to `--output-format=csv` argument allows an uncompressed CSV to be produced which may be useful while testing in dummy data or if using Stata for analysis of this file. To import the compressed file in Python, you can use `pd.read_csv(<file>, compression='gzip')`. 
 
 The size of the dummy dataset is determined by the `population_size` option [in the `project.yaml`](actions-pipelines.md#project-yaml-format).
 

--- a/docs/actions-cohortextractor.md
+++ b/docs/actions-cohortextractor.md
@@ -56,13 +56,15 @@ A basic `generate_cohort` action looks like this:
 
 ```yaml
 generate_study_cohort
-  run: cohortextractor:latest generate_cohort --output-format=csv.gz
+  run: cohortextractor:latest generate_cohort --output-format =csv.gz
   outputs:
     highly_sensitive:
       data: output/input.csv.gz
+    ### This file is produced in compressed format. If using Stata for your analysis you may need to remove 
+    ### the --output-format option and the .gz file extension to produce an uncompressed CSV instead.
 ```
 
-This produces a zipped file to reduce storage space required in the backend. Missing the `--output-format=csv.gz` argument allows an uncompressed CSV to be produced which may be useful while testing in dummy data. To import the compressed file in Python, you can use `pd.read_csv(<file>, compression='gzip')`. 
+This produces a zipped file to reduce storage space required in the backend. Missing the `--output-format=csv.gz` argument allows an uncompressed CSV to be produced which may be useful while testing in dummy data or if using Stata for analysis of this file. To import the compressed file in Python, you can use `pd.read_csv(<file>, compression='gzip')`. 
 
 The size of the dummy dataset is determined by the `population_size` option [in the `project.yaml`](actions-pipelines.md#project-yaml-format).
 
@@ -81,6 +83,8 @@ generate_study_cohort
   outputs:
     highly_sensitive:
       data: output/input_cohort2.csv.gz
+      ### This file is produced in compressed format. If using Stata you may need to remove the --output-format option and 
+      ### the .gz file extension to produce an uncompressed CSV instead.
 ```
 
 You can change the location of the outputted `.csv.gz` file using the `--output-dir` option, for example `run: cohortextractor:latest generate_cohort --output-dir output/cohorts`

--- a/docs/actions-pipelines.md
+++ b/docs/actions-pipelines.md
@@ -36,10 +36,12 @@ expectations:
 actions:
 
   generate_study_population:
-    run: cohortextractor:latest generate_cohort --study-definition study_definition --output-format=csv.gz
+    run: cohortextractor:latest generate_cohort --study-definition study_definition
     outputs:
       highly_sensitive:
-        cohort: output/input.csv.gz
+        cohort: output/input.csv
+        ### Note: When using analysis tools other than Stata it is recommended to add option --output-format='csv.gz' to the 'run' command
+	### and add .gz to the output file path; this produces a compressed file to minimise file size. (Stata cannot load these files without first unzipping).
 
   run_model:
     run: stata-mp:latest analysis/model.do
@@ -54,9 +56,9 @@ This example declares the pipeline `version`, the `population_size` for the dumm
 
 You only need to change `version` if you want to take advantage of features of newer versions of the pipeline framework.
 
-The `generate_study_population` action will create the highly sensitive `input.csv.gz` dataset.
+The `generate_study_population` action will create the highly sensitive `input.csv` dataset.
 It will be dummy data when run locally, and will be based on real data from the OpenSAFELY database when run in the secure environment.
-The `run_model` action will run a Stata script called `model.do` based on the the `input.csv.gz` created by the previous action.
+The `run_model` action will run a Stata script called `model.do` based on the the `input.csv` created by the previous action.
 It will output two moderately sensitive files `cox-model.txt` and `survival-plot.png`, which can be checked and released if appropriate.
 
 
@@ -106,7 +108,7 @@ To run the first action in the example above, using dummy data, you can use:
 opensafely run generate_study_population
 ```
 
-This will generate the `input.csv.gz` file as explained in the [cohortextractor](actions-cohortextractor.md) section.
+This will generate the `input.csv` file as explained in the [cohortextractor](actions-cohortextractor.md) section.
 
 To run the second action you can use:
 
@@ -117,7 +119,7 @@ opensafely run run_model
 It will create the two files as specified in the `analysis/model.do` script.
 
 To force the dependencies to be run you can use for example `opensafely run run_model --force-run-dependencies`, or `-f` for short.
-This will ensure for example that both the `run_model` and `generate_study_population` actions are run, even if `input.csv.gz` already exists.
+This will ensure for example that both the `run_model` and `generate_study_population` actions are run, even if `input.csv` already exists.
 
 To run all actions, you can use a special `run_all` action which is created for you (no need to define it in your `project.yaml`):
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -569,6 +569,8 @@ This code reads the CSV of patient data, and saves a histogram of ages to a new 
         outputs:
           highly_sensitive:
             cohort: output/input.csv
+	    ## note: when running studies for real it is recommended to add the option --output-format='csv.gz' to the run command, 
+	    ## and add '.gz' to the output file path, to produce the output in compressed form to reduce file size.
 
       describe:
         run: python:latest python analysis/report.py
@@ -592,6 +594,8 @@ This code reads the CSV of patient data, and saves a histogram of ages to a new 
         outputs:
           highly_sensitive:
             cohort: output/input.csv
+	    ## note: when running studies for real it is recommended to add the option --output-format='csv.gz' to the run command, 
+	    ## and add '.gz' to the output file path, to produce the output in compressed form to reduce file size.
 
       describe:
         run: r:latest analysis/report.R

--- a/docs/news.md
+++ b/docs/news.md
@@ -1,7 +1,7 @@
 
 This page lists significant improvements to the platform since June 2021, with the most recent at the top. We suggest you check it regularly.
 
-* 2021-09-06: Show how to extract cohortextractor output in compressed gzip (`csv.gz`) format - recommended to be used in all studies to minimise file storage size. This is now shown in all parts of documentation with cohortextractor steps e.g. [this page](/actions-cohortextractor/#generate_cohort)
+* 2021-09-06: Show how to extract cohortextractor output in compressed gzip (`csv.gz`) format - recommended to be used in all studies to minimise file storage size. (However, CSVs can still be used where Stata is used for analysis). This is now shown in all parts of documentation with cohortextractor steps e.g. [this page](/actions-cohortextractor/#generate_cohort)
 * 2021-07-21: Added [support for users to provide their own dummy data](/study-def-expectations#providing-your-own-dummy-data)
 * 2021-07-07: Added [a page](https://docs.opensafely.org/permissions) in the docs explaining (briefly) how permissions work [#303](https://github.com/opensafely/documentation/pull/303)
 * 2021-06-11: Add ability to query a patient's _health care worker_ status in vaccination records (TPP backend only) [docs](https://docs.opensafely.org/study-def-variables/#cohortextractor.patients.with_healthcare_worker_flag_on_covid_vaccine_record), [#567](https://github.com/opensafely-core/cohort-extractor/pull/567)


### PR DESCRIPTION
Make it more clear that csv.gz format is recommended but csv may need to be used instead if Stata is being used for analysis