### PR TITLE
with_complete_history_between() as this is not implemented

### DIFF
--- a/docs/study-def-variables.md
+++ b/docs/study-def-variables.md
@@ -19,9 +19,6 @@ These variables are derived from data held in the patients' primary care records
 ::: cohortextractor.patients.date_deregistered_from_all_supported_practices
 &nbsp;
 
-::: cohortextractor.patients.with_complete_history_between
-&nbsp;
-
 ::: cohortextractor.patients.with_complete_gp_consultation_history_between
 &nbsp;
 


### PR DESCRIPTION
Should clarify and close https://github.com/opensafely/documentation/issues/417 


This PR should be viewed with the corresponding PR on the cohort-extractor which updates the contents of the docstrings to make  `registered_with_one_practice_between` and  `with_complete_gp_consultation_history_between ` clearer