### PR TITLE
Improve parameter variable notes

### DIFF
--- a/docs/study-def-expectations.md
+++ b/docs/study-def-expectations.md
@@ -83,21 +83,24 @@ The following options are currently available for dummy data (note numeric value
 *	`{"date": {"earliest": "1900-01-01", "latest": "today"}, "rate" : "uniform"}`
 
 
-### Specifc parameters/variable notes
+### Specific parameters/variable notes
 
 `"incidence"` has a slightly different meaning dependent on the variable type it is applied to:
+
 * binary: describes actual incidence (0.5 means values are expected to be positive 50% of the time)
 * int/float/categorical: indicates non-missingness (0.5 means values are expected to be present - non-missing - 50% of the time)
 
 `"rate"` 
+
 * used for the distribution of date values, with either:
-  * `"exponential_increase"`
-  * `"uniform"`
+    * `"exponential_increase"`
+    * `"uniform"`
     
 * or for non-date values:
-  * `"universal"`: indicates every patient is expected to have a value (i.e. an alias for `incidence=1`)
+    * `"universal"`: indicates every patient is expected to have a value (i.e. an alias for `incidence=1`)
     
 `"distribution"`(numeric variables) currently has two possible options:
+
 * `normal`
 * `population_ages`: samples from the distribution of ages in the UK taken from [the Office for National Statistics](https://www.ons.gov.uk/peoplepopulationandcommunity/populationandmigration/populationprojections/datasets/tablea21principalprojectionukpopulationinagegroups).
 

--- a/docs/study-def-expectations.md
+++ b/docs/study-def-expectations.md
@@ -83,26 +83,25 @@ The following options are currently available for dummy data (note numeric value
 *	`{"date": {"earliest": "1900-01-01", "latest": "today"}, "rate" : "uniform"}`
 
 
-### Specific parameters/variable notes
+### Notes on parameters/variables
 
-`"incidence"` has a slightly different meaning dependent on the variable type it is applied to:
+**Incidence**
 
-* binary: describes actual incidence (0.5 means values are expected to be positive 50% of the time)
-* int/float/categorical: indicates non-missingness (0.5 means values are expected to be present - non-missing - 50% of the time)
+* For binary variables, `{"incidence": 0.5}` means we expect values to be `1` in 50% of cases and `0` in 50% of cases.
+* For integer, float, and categorical variables, `{"incidence": 0.5}` means we expect values to occur in 50% of cases and not to occur (i.e. to be missing) in 50% of cases.
 
-`"rate"` 
+**Rate**
 
-* used for the distribution of date values, with either:
-    * `"exponential_increase"`
-    * `"uniform"`
-    
-* or for non-date values:
-    * `"universal"`: indicates every patient is expected to have a value (i.e. an alias for `incidence=1`)
-    
-`"distribution"`(numeric variables) currently has two possible options:
+* For date variables, rate describes the distribution and can be either `"exponential_increase"` or `"uniform"`.
+* For binary variables rate can be `"universal"`, which means we expect values to be `1` in all cases.
+  This is an alias for `{"incidence": 1.0}`.
+* For integer, float, and categorical variables rate can be `"universal"`, which means we expect values to occur in all cases.
+  This is an alias for `{"incidence": 1.0}`.
 
-* `normal`
-* `population_ages`: samples from the distribution of ages in the UK taken from [the Office for National Statistics](https://www.ons.gov.uk/peoplepopulationandcommunity/populationandmigration/populationprojections/datasets/tablea21principalprojectionukpopulationinagegroups).
+**Distribution**
+
+* `"normal"` means we expect a normal distribution.
+* `"population_ages"`: means we expect the distribution to match that of the distribution of ages in the UK from [the Office for National Statistics](https://www.ons.gov.uk/peoplepopulationandcommunity/populationandmigration/populationprojections/).
 
 ## Providing your own dummy data
 


### PR DESCRIPTION
Whilst working on opensafely-core/cohort-extractor#585, I wrote a study definition that generated dummy data. I felt the documentation about dummy data could be improved, first by fixing a bulleted list and second by rewording the section that was called *Specific parameters/variable notes* and is now called *Notes on parameters/variables*.

Hopefully the first commit is straightforward. It ensures that mkdocs does what we intend it to do. The second commit is based largely on my understanding of these parameters/variables, which I've tested against the study definition in [`test-reusable-actions`](https://github.com/opensafely-actions/test-reusable-actions).