### PR TITLE
Warn ICNARC data is for ICNARC researchers only

### DIFF
--- a/docs/dataset-icnarc.md
+++ b/docs/dataset-icnarc.md
@@ -1,6 +1,10 @@
 The ICNARC-CMP  dataset contains information on covid-related intensive care admissions in England.
 
 !!! warning
+    ICNARC data can only be used in collaboration with ICNARC researchers who must be involved in working on the study and writing it up.
+    Please contact your co-pilot, or <team@opensafely.org> if you have any questions.
+
+!!! warning
     Data from ICNARC were last imported on 21-Jan-2021, with no further imports currently planned. Alternative data on ICU admission can be gleaned from SUS (i.e. returning=days_in_critical_care).
 
 From ICNARC's website:

--- a/docs/study-def-variables.md
+++ b/docs/study-def-variables.md
@@ -78,6 +78,10 @@ These variables are derived from data held in the patients' primary care records
 
 ## ICNARC
 !!! warning
+    ICNARC data can only be used in collaboration with ICNARC researchers who must be involved in working on the study and writing it up.
+    Please contact your co-pilot, or <team@opensafely.org> if you have any questions.
+
+!!! warning
     Data from ICNARC were last imported on 21-Jan-2021, with no further imports currently planned. Alternative data on ICU admission can be gleaned from SUS (i.e. returning=days_in_critical_care).
 
 These variables are derived from the Intensive Care National Audit and Research Centre Case-Mix Programme (ICNARC-CMP), which collects information on ICU admissions across England.


### PR DESCRIPTION
Thank you @amirmehrkar for providing the text of this warning.

I've searched the repo for instances of ICNARC. These two warnings cover them, with the exception of this incidental mention, which is on the [SystmOne primary care](https://docs.opensafely.org/dataset-systmone/) page:

> For some datasets (ICNARC), OpenSAFELY receives the hashed NHS numbers from the external dataset and the matching occurs inside OpenSAFELY. The matched IDs are then sent back and the matched records are returned to OpenSAFELY.

I do not think we need a warning on this page.

Closes opensafely-core/cohort-extractor#678