### PR TITLE
Add link-databuilder command

### DIFF
--- a/justfile
+++ b/justfile
@@ -94,3 +94,7 @@ fix: devenv
 # Run the dev project
 run: devenv
     mkdocs serve -a localhost:8910
+
+
+link-databuilder:
+    ln -sf ../databuilder/backend_docs.json .


### PR DESCRIPTION
This adds `link-databuilder` to the justfile so we can make sure a symlink to the databuilder's backend docs JSON dump exists.

I've avoided handling the cloning of the databuilder repo since we'll need a functioning virtualenv to run the tool and that is best left to the project.

Note: This is blocked on renaming the `cohort-extractor-v2` repo to `databuilder` to avoid churn in this repo.