### PR TITLE
Fix default PYTHON_VERSION in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -23,7 +23,7 @@ clean:
 virtualenv:
     #!/usr/bin/env bash
     # allow users to specify python version in .env
-    PYTHON_VERSION=${PYTHON_VERSION:-python3.9}
+    PYTHON_VERSION=${PYTHON_VERSION:-python3.7}
 
     # create venv and upgrade pip
     test -d $VIRTUAL_ENV || { $PYTHON_VERSION -m venv $VIRTUAL_ENV && $PIP install --upgrade pip; }


### PR DESCRIPTION
The default Python version should be consistent between:

* `justfile`
* `.python-version`
* `.github/workflows/build.yml`

---

Follow up: As per @benbc's [suggestion][1], it would be good to add an assertion to `build.yaml` to check for consistency between `justfile` and `.python-version`. I think this would require refactoring `build.yml`, which seems non-trivial:

* Checking that `actions/setup-python` doesn't set `PYTHON_VERSION`
* Calling `just prodenv` from within `build.yml` (rather than `pip install ...`)
* Testing that `python --version` is equal to `cat .python-version`, or nearly equal (not necessarily to the patch release)

Could I double-check my understanding of ☝🏻? If I'm on the right track, then I'll make a separate issue.

[1]: https://ebmdatalab.slack.com/archives/C63UXGB8E/p1642520205077800