### PR TITLE
Refer to OpenSAFELY policies on output release 

### DIFF
--- a/docs/releasing-files.md
+++ b/docs/releasing-files.md
@@ -1,5 +1,7 @@
 All outputs from OpenSAFELY pipelines are subject to [tiered levels of scrutiny](security-levels.md), to provide assurance that identifiable data is not leaked accidentally, or maliciously.
 
+## Review of outputs before requesting a release
+
 The final tier is review of so-called "Level 4" outputs, where the OpenSAFELY framework stores outputs labelled as `moderately_sensitive` in the `project.yaml` file.
 
 If you have Level 4 access you can log in and review your aggregated results, and perform any necessary redactions before requesting files to be released. 
@@ -30,7 +32,16 @@ You will find your files to review in `D:\Level4Files\workspaces\<workspacename>
     discussion](https://github.com/opensafely/documentation/discussions/251#discussioncomment-1767887)
     for a description of the problem.
 
-Level 4 outputs **can only be released by specific members of the OpenSAFELY team**. When you are ready to request a release of your aggregated results, and only the minimum outputs necessary (for which you have also applied any necessary disclosure controls, such as small number suppression) **please [complete this form](documents/OpenSAFELY_Output_Review_Form_15_11_21.docx) and email us at <datarelease@opensafely.org>**.
+## Release of outputs
+
+Level 4 outputs **can only be released by specific members of the OpenSAFELY team**.
+
+Before making a request for outputs to be released, **you must verify that your request adheres to the current [Permitted Study Results Policy](https://www.opensafely.org/policies-for-researchers/#permitted-study-results-policy)**.
+
+!!! warning
+    The Permitted Study Results Policy may be updated: **always check the policy before every new release request.**
+
+When you are ready to request a release of your aggregated results, and only the minimum outputs necessary (for which you have also applied any necessary disclosure controls, such as small number suppression) **please [complete this form](documents/OpenSAFELY_Output_Review_Form_15_11_21.docx) and email us at <datarelease@opensafely.org>**.
 
 !!! warning
     ** Data may only be shared with individuals without Level 4 access after they have been released outside of the secure area. You MUST NOT screen share (or share via any other means) any results that have not been released through the official process.**
@@ -38,10 +49,19 @@ Level 4 outputs **can only be released by specific members of the OpenSAFELY tea
 !!! warning
     ** DO NOT release your aggregated study results to your GitHub repository yourself (unless you have been given permission by OpenSAFELY).**
 
+### Advice on requesting an output release
+
+Our resources for checking outputs are not unlimited, therefore it is advised to ensure you have all of your outputs ready at the same time for your project (or its current phase) so they can be reviewed together. Another reason to ensure your analyses are complete is that re-running your study definition a short time later (e.g. to create an additional variable) may produce small differences in the previous results, e.g. due to movement of patients or codes added retrospectively to patient records. If you have already released similar results, any small changes in new outputs may be subject to small number suppression which may prevent the new outputs being released at all. (One solution to minimise this issue is to round all of your results, e.g. to the nearest 5).
+
 !!! note
-    Individual researchers who have Level 4 access have responsibility for redacting sensitive information, or choosing not to publish it at all. The study author should do everything they can to make this easy; for example, carrying out low number suppression automatically, documenting code clearly, and only selecting essential items for publication when deciding what to label as `moderately_sensitive`. The researcher must ensure that their release request adheres to the [Permitted Study Results Policy](https://www.opensafely.org/policies-for-researchers/#permitted-study-results-policy). This policy is subject to change and so must be checked before every request for release."
+    Individual researchers who have Level 4 access have responsibility for redacting sensitive information, or choosing not to publish it at all. The study author should do everything they can to make this easy; for example, carrying out low number suppression automatically, documenting code clearly, and only selecting essential items for publication when deciding what to label as `moderately_sensitive`.
     
-TIP: Our resources for checking outputs are not unlimited, therefore it is advised to ensure you have all of your outputs ready at the same time for your project (or its current phase) so they can be reviewed together. Another reason to ensure your analyses are complete is that re-running your study definition a short time later (e.g. to create an additional variable) may produce small differences in the previous results, e.g. due to movement of patients or codes added retrospectively to patient records. If you have already released similar results, any small changes in new outputs may be subject to small number suppresion which may prevent the new outputs being released at all. (One solution to minimise this issue is to round all of your results, e.g. to the nearest 5). 
+### What to do after an output is released
+
+!!! warning
+    **You must follow the rules in our [Data Sharing/Publication Policy](https://www.opensafely.org/policies-for-researchers/#acknowledgment-and-data-sharing--publication-policy)**.
+
+    Before sharing or publishing results, consult the "Sharing of Results" and "Publication of Results" sections in that policy. Check this for each dataset that you have used: rules may vary.
 
 Once released, your results will be available in a new branch (`release-candidates`). This branch should be merged into `main`. A new branch of the same name will be created with any further releases so there is no need to keep the branch open.
 


### PR DESCRIPTION
As requested by @amirmehrkar.

While here, edited the page slightly. This is largely to reorder the content and break it up into smaller chunks: the original content is all still pretty much there unchanged. The page, as was, was quite a large chunk of unbroken text. The subheadings and reordering hopefully help the reader find the context for the instructions they are reading.