### PR TITLE
Set up pre-commit hooks for the databuilder directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+default_language_version:
+  python: python3.10
+
+files: "^databuilder/"
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 21.12b0
+    hooks:
+    - id: black
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+    - id: flake8
+      additional_dependencies:
+      - "flake8-builtins"
+      - "flake8-implicit-str-concat"
+      - "flake8-no-pep420"
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+    - id: isort
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+    - id: debug-statements
+    - id: check-ast
+    - id: check-json
+    - id: check-toml
+    - id: check-yaml
+    - id: detect-private-key


### PR DESCRIPTION
This sets up pre-commit for only the databuilder directory, using the global `files` key.