### PR TITLE
Use an include as warning for Data Builder

### DIFF
--- a/docs/data-definition.md
+++ b/docs/data-definition.md
@@ -1,4 +1,4 @@
-!!! danger "This page is for use with [the OpenSAFELY Databuilder](https://github.com/opensafely-core/databuilder/) which is currently unreleased."
+---8<-- 'includes/data-builder-danger-header.md'
 
 ## What is a Data Definition?
 

--- a/includes/data-builder-danger-header.md
+++ b/includes/data-builder-danger-header.md
@@ -1,0 +1,13 @@
+!!! danger
+
+    This page discusses the new [OpenSAFELY Data
+    Builder](https://github.com/opensafely-core/databuilder) for
+    accessing OpenSAFELY data sources.
+    
+    **Use OpenSAFELY [cohort-extractor](study-def.md), unless you are
+    specifically involved in the development or testing of Data
+    Builder.**
+
+    OpenSAFELY Data Builder and its documentation are still undergoing
+    extensive development. We will announce when Data Builder is ready
+    for general use on the [Platform News](news.md) page.


### PR DESCRIPTION
So we can reuse this on any Data Builder documentation, instead of
copy-pasting. It also results in smaller diffs when removing or changing
this content.