### PR TITLE
Codelist opcs

### DIFF
--- a/docs/codelist-creation.md
+++ b/docs/codelist-creation.md
@@ -19,7 +19,7 @@ The current coding systems available in the OpenCodelists builder are listed bel
 
 Each codelist must use exactly one of these systems.
 
-OPCS-4 codes are no currently supported by the OpenCodelists builder as we do not currently have the full list of available OPCS-4 codes. However, you can find instructions to manually upload an existing OPCS-4 codelist [here]().
+OPCS-4 codes are not currently supported by the OpenCodelists builder as we do not currently have the full list of available OPCS-4 codes. However, you can find instructions to manually upload an existing OPCS-4 codelist [here](https://www.opencodelists.org/docs/#creating-a-codelist-from-a-csv-file).
 ## Workflow
 
 The general workflow for creating codelists is as follows:


### PR DESCRIPTION
This adds in a link to some info on creating an opcs-4 codelist on OpenCodelists and removes some content which I think is better placed in the OpenCodelists docs.

Draft for now until OpenCodelists docs have been updated