### PR TITLE
Add databuilder Docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,6 +21,18 @@ If you have added new functions, you will need to add an explicit
 reference to them in
 [docs/study-def-variables.md](./docs/study-def-variables.md).
 
+
+### Updating Data Builder Definitions
+
+Data Builder is a documentation dependency which we can't install directly.
+Cloudflare Pages' latest Python version is 3.7, but Data Builder is using 3.9 features.
+Rather than limit Data Builder to the versions supported by Cloudflare Pages, we've opted to have it generate a JSON file from Data Builder and commit that JSON to this repo.
+
+Run `just databuilder/generate-docs` to generate the JSON file using `databuilder` installed in the `databuilder` subdirectory of this repo.
+
+If the JSON file has changed you might need to update [the plugin which uses it to render pages](https://github.com/opensafely-core/mkdocs-opensafely-backend-contracts/).
+
+
 ### Updating via Dependabot
 
 You can update the opensafely-cohort-extractor package via Dependabot.

--- a/databuilder/justfile
+++ b/databuilder/justfile
@@ -121,3 +121,7 @@ watch-examples:
     #!/usr/bin/env bash
     project_root=$(git rev-parse --show-toplevel)
     $BIN/watchmedo shell-command --patterns="*.py" --recursive --command="just ${project_root}/databuilder/extract" "${project_root}/databuilder/snippets"
+
+
+generate-docs:
+    $BIN/python -m databuilder generate_docs --location=../

--- a/databuilder/requirements.prod.in
+++ b/databuilder/requirements.prod.in
@@ -4,6 +4,6 @@
 # pip-compile --generate-hashes --output-file=requirements.prod.txt requirements.prod.in
 snex
 
-# Dependabot doesn't seem to touch this dependency, likely because it's pinned,
-#so we have a script to update it, run: just databuilder/upgrade-databuilder
-https://github.com/opensafely-core/databuilder/archive/refs/tags/v0.18.3.zip
+# Dependabot doesn't seem to touch this dependency, likely because it's pinned,
+# so we have a script to update it, run: just databuilder/upgrade-databuilder
+https://github.com/opensafely-core/databuilder/archive/refs/tags/v0.29.0.zip

--- a/databuilder/requirements.prod.txt
+++ b/databuilder/requirements.prod.txt
@@ -189,8 +189,8 @@ numpy==1.22.1 \
     --hash=sha256:e60ef82c358ded965fdd3132b5738eade055f48067ac8a5a8ac75acc00cad31f \
     --hash=sha256:f8ad59e6e341f38266f1549c7c2ec70ea0e3d1effb62a44e5c3dba41c55f0187
     # via pandas
-opensafely-databuilder @ https://github.com/opensafely-core/databuilder/archive/refs/tags/v0.18.3.zip \
-    --hash=sha256:751e183e92ac68880bcbcbd2f393079d2330312630c2ef64cb11a3537533ccbc
+opensafely-databuilder @ https://github.com/opensafely-core/databuilder/archive/refs/tags/v0.29.0.zip \
+    --hash=sha256:eec421f9422abadad053d43f735177309326c42aac58298263f72c1142d6f7da
     # via -r requirements.prod.in
 pandas==1.4.0 \
     --hash=sha256:0f19504f2783526fb5b4de675ea69d68974e21c1624f4b92295d057a31d5ec5f \

--- a/databuilder/snippets/dsl.py
+++ b/databuilder/snippets/dsl.py
@@ -1,24 +1,26 @@
 # :snippet imports
-from databuilder.dsl import Cohort
-from databuilder.tables import clinical_events, practice_registrations
+# TODO: replace this when the new DSL is in
+# from databuilder.dsl import Cohort
+# from databuilder.tables import clinical_events, practice_registrations
 
 
 # :endsnippet
 
 # :snippet dataset-definition
-cohort = Cohort()
+# TODO: replace this when the new DSL is in
+# cohort = Cohort()
 
-index_date = "2020-11-01"
-registered = (
-    practice_registrations.filter(practice_registrations.date_start <= index_date)
-    .filter(practice_registrations.date_end >= index_date)
-    .exists_for_patient()
-)
-cohort.set_population(registered)
+# index_date = "2020-11-01"
+# registered = (
+#     practice_registrations.filter(practice_registrations.date_start <= index_date)
+#     .filter(practice_registrations.date_end >= index_date)
+#     .exists_for_patient()
+# )
+# cohort.set_population(registered)
 
-cohort.code = (
-    clinical_events.sort_by(clinical_events.date)
-    .first_for_patient()
-    .select_column(clinical_events.code)
-)
+# cohort.code = (
+#     clinical_events.sort_by(clinical_events.date)
+#     .first_for_patient()
+#     .select_column(clinical_events.code)
+# )
 # :endsnippet

--- a/docs/contracts-reference.md
+++ b/docs/contracts-reference.md
@@ -10,4 +10,13 @@ code](https://github.com/opensafely-core/databuilder/tree/main/databuilder/contr
 via a [MkDocs
 plugin](https://github.com/opensafely-core/mkdocs-opensafely-backend-contracts).
 
+
+!!! contract:databuilder.contracts.contracts.WIP_ClinicalEvents
+
+!!! contract:databuilder.contracts.contracts.PatientDemographics
+
+!!! contract:databuilder.contracts.contracts.WIP_PracticeRegistrations
+
+
+
 ---8<-- 'includes/glossary.md'

--- a/docs/data-backends.md
+++ b/docs/data-backends.md
@@ -15,9 +15,12 @@ different backends adhere to contracts? Can this be automated in future
 somehow?
 
 ## TPP
+!!! backend:TPPBackend
 
 ## Databricks
+!!! backend:DatabricksBackend
 
 ## Graphnet
+!!! backend:GraphnetBackend
 
 ---8<-- 'includes/glossary.md'

--- a/examples/src-dataset-definition.md
+++ b/examples/src-dataset-definition.md
@@ -1,17 +1,18 @@
 ```python
-cohort = Cohort()
+# TODO: replace this when the new DSL is in
+# cohort = Cohort()
 
-index_date = "2020-11-01"
-registered = (
-    practice_registrations.filter(practice_registrations.date_start <= index_date)
-    .filter(practice_registrations.date_end >= index_date)
-    .exists_for_patient()
-)
-cohort.set_population(registered)
+# index_date = "2020-11-01"
+# registered = (
+#     practice_registrations.filter(practice_registrations.date_start <= index_date)
+#     .filter(practice_registrations.date_end >= index_date)
+#     .exists_for_patient()
+# )
+# cohort.set_population(registered)
 
-cohort.code = (
-    clinical_events.sort_by(clinical_events.date)
-    .first_for_patient()
-    .select_column(clinical_events.code)
-)
+# cohort.code = (
+#     clinical_events.sort_by(clinical_events.date)
+#     .first_for_patient()
+#     .select_column(clinical_events.code)
+# )
 ```

--- a/examples/src-imports.md
+++ b/examples/src-imports.md
@@ -1,4 +1,5 @@
 ```python
-from databuilder.dsl import Cohort
-from databuilder.tables import clinical_events, practice_registrations
+# TODO: replace this when the new DSL is in
+# from databuilder.dsl import Cohort
+# from databuilder.tables import clinical_events, practice_registrations
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ plugins:
       custom_templates: templates
       watch:
         - examples
+  - contracts
 
 markdown_extensions:
   - pymdownx.snippets:

--- a/public_docs.json
+++ b/public_docs.json
@@ -1,0 +1,126 @@
+{
+  "backends": [
+    {
+      "name": "DatabricksBackend",
+      "tables": [
+        "WIP_SimplePatientDemographics",
+        "WIP_Prescriptions",
+        "WIP_HospitalAdmissions"
+      ]
+    },
+    {
+      "name": "GraphnetBackend",
+      "tables": [
+        "PatientDemographics",
+        "WIP_ClinicalEvents",
+        "WIP_PracticeRegistrations",
+        "WIP_CovidTestResults",
+        "WIP_HospitalizationsWithoutSystem",
+        "WIP_PatientAddress"
+      ]
+    },
+    {
+      "name": "TPPBackend",
+      "tables": [
+        "Patients",
+        "WIP_ClinicalEvents",
+        "WIP_PracticeRegistrations",
+        "WIP_CovidTestResults",
+        "WIP_Hospitalizations",
+        "WIP_PatientAddress"
+      ]
+    }
+  ],
+  "contracts": [
+    {
+      "name": "PatientDemographics",
+      "dotted_path": "databuilder.contracts.contracts.PatientDemographics",
+      "docstring": [
+        "Provides demographic information about patients."
+      ],
+      "columns": [],
+      "contract_support": []
+    },
+    {
+      "name": "WIP_ClinicalEvents",
+      "dotted_path": "databuilder.contracts.contracts.WIP_ClinicalEvents",
+      "docstring": [
+        "TODO."
+      ],
+      "columns": [],
+      "contract_support": []
+    },
+    {
+      "name": "WIP_HospitalAdmissions",
+      "dotted_path": "databuilder.contracts.contracts.WIP_HospitalAdmissions",
+      "docstring": [
+        "TODO."
+      ],
+      "columns": [],
+      "contract_support": []
+    },
+    {
+      "name": "WIP_Hospitalizations",
+      "dotted_path": "databuilder.contracts.contracts.WIP_Hospitalizations",
+      "docstring": [
+        "TODO."
+      ],
+      "columns": [],
+      "contract_support": []
+    },
+    {
+      "name": "WIP_HospitalizationsWithoutSystem",
+      "dotted_path": "databuilder.contracts.contracts.WIP_HospitalizationsWithoutSystem",
+      "docstring": [
+        "TODO."
+      ],
+      "columns": [],
+      "contract_support": []
+    },
+    {
+      "name": "WIP_PatientAddress",
+      "dotted_path": "databuilder.contracts.contracts.WIP_PatientAddress",
+      "docstring": [
+        "TODO."
+      ],
+      "columns": [],
+      "contract_support": []
+    },
+    {
+      "name": "WIP_PracticeRegistrations",
+      "dotted_path": "databuilder.contracts.contracts.WIP_PracticeRegistrations",
+      "docstring": [
+        "TODO."
+      ],
+      "columns": [],
+      "contract_support": []
+    },
+    {
+      "name": "WIP_Prescriptions",
+      "dotted_path": "databuilder.contracts.contracts.WIP_Prescriptions",
+      "docstring": [
+        "TODO."
+      ],
+      "columns": [],
+      "contract_support": []
+    },
+    {
+      "name": "WIP_CovidTestResults",
+      "dotted_path": "databuilder.contracts.contracts.WIP_CovidTestResults",
+      "docstring": [
+        "TODO."
+      ],
+      "columns": [],
+      "contract_support": []
+    },
+    {
+      "name": "WIP_SimplePatientDemographics",
+      "dotted_path": "databuilder.contracts.contracts.WIP_SimplePatientDemographics",
+      "docstring": [
+        "TODO."
+      ],
+      "columns": [],
+      "contract_support": []
+    }
+  ]
+}

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -17,9 +17,9 @@ importlib-metadata==4.8.2 \
     #   -c requirements.prod.txt
     #   click
     #   pep517
-pep517==0.11.0 \
-    --hash=sha256:3fa6b85b9def7ba4de99fb7f96fe3f02e2d630df8aa2720a5cf3b183f087a738 \
-    --hash=sha256:e1ba5dffa3a131387979a68ff3e391ac7d645be409216b961bc2efe6468ab0b2
+pep517==0.12.0 \
+    --hash=sha256:931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0 \
+    --hash=sha256:dd884c326898e2c6e11f9e0b64940606a93eb10ea022a2e067959f3a110cf161
     # via pip-tools
 pip-tools==6.5.1 \
     --hash=sha256:80f1cfc7156e4a4465b1a46a6bb3599587909537db1a149cf3a6b73eed979ee4 \
@@ -53,9 +53,9 @@ zipp==3.6.0 \
     #   pep517
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.2.4 \
-    --hash=sha256:0eb8a1516c3d138ae8689c0c1a60fde7143310832f9dc77e11d8a4bc62de193b \
-    --hash=sha256:fa9ebb85d3fd607617c0c44aca302b1b45d87f9c2a1649b46c26167ca4296323
+pip==21.3.1 \
+    --hash=sha256:deaf32dcd9ab821e359cd8330786bcd077604b5c5730c0b096eda46f95c24a2d \
+    --hash=sha256:fd11ba3d0fdb4c07fbc5ecbba0b1b719809420f25038f8ee3cd913d3faa3033a
     # via pip-tools
 setuptools==59.4.0 \
     --hash=sha256:b4c634615a0cf5b02cf83c7bedffc8da0ca439f00e79452699454da6fbd4153d \

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -4,6 +4,7 @@
 # pip-compile --generate-hashes --output-file=requirements.prod.txt requirements.prod.in
 
 mkdocs
-mkdocstrings
 mkdocs-material
+https://github.com/opensafely-core/mkdocs-opensafely-backend-contracts/archive/bf1a19894a9d37c6673f02c7cdfd89e6a72e3101.zip#mkdocs-opensafely-backend-contracts
+mkdocstrings
 opensafely-cohort-extractor

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -109,6 +109,10 @@ decorator==5.1.0 \
     --hash=sha256:7b12e7c3c6ab203a29e157335e9122cb03de9ab7264b137594103fd4a683b374 \
     --hash=sha256:e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7
     # via retry
+first==2.0.2 \
+    --hash=sha256:8d8e46e115ea8ac652c76123c0865e3ff18372aef6f03c22809ceefcea9dec86 \
+    --hash=sha256:ff285b08c55f8c97ce4ea7012743af2495c9f1291785f163722bd36f6af6d3bf
+    # via mkdocs-opensafely-backend-contracts
 fonttools==4.28.2 \
     --hash=sha256:dca694331af74c8ad47acc5171e57f6b78fac5692bf050f2ab572964577ac0dd \
     --hash=sha256:eff1da7ea274c54cb8842853005a139f711646cbf6f1bcfb6c9b86a627f35ff0
@@ -400,6 +404,9 @@ mkdocs-material-extensions==1.0.3 \
     --hash=sha256:a82b70e533ce060b2a5d9eb2bc2e1be201cf61f901f93704b4acf6e3d5983a44 \
     --hash=sha256:bfd24dfdef7b41c312ede42648f9eb83476ea168ec163b613f9abd12bbfddba2
     # via mkdocs-material
+mkdocs-opensafely-backend-contracts @ https://github.com/opensafely-core/mkdocs-opensafely-backend-contracts/archive/bf1a19894a9d37c6673f02c7cdfd89e6a72e3101.zip \
+    --hash=sha256:37629dec3b240231c366d229e8b4c3b45a21e51c6067c222961ef0763fafd209
+    # via -r requirements.prod.in
 mkdocstrings==0.18.0 \
     --hash=sha256:01d8ab962fc1f388c9b15cbf8c078b8738f92adf983b626d74135aaee2bce33a \
     --hash=sha256:75e277f6a56a894a727efcf6d418d36cd43d4db7da9614c2dc23300e257d95ad
@@ -761,10 +768,9 @@ tomli==1.2.2 \
     --hash=sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee \
     --hash=sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade
     # via setuptools-scm
-typing-extensions==3.10.0.2 \
-    --hash=sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e \
-    --hash=sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7 \
-    --hash=sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34
+typing-extensions==4.1.1 \
+    --hash=sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42 \
+    --hash=sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2
     # via
     #   importlib-metadata
     #   pytkdocs
@@ -798,9 +804,9 @@ watchdog==2.1.6 \
     --hash=sha256:e0f30db709c939cabf64a6dc5babb276e6d823fd84464ab916f9b9ba5623ca15 \
     --hash=sha256:e92c2d33858c8f560671b448205a268096e17870dcf60a9bb3ac7bfbafb7f5f9
     # via mkdocs
-wheel==0.37.0 \
-    --hash=sha256:21014b2bd93c6d0034b6ba5d35e4eb284340e09d63c59aef6fc14b0f346146fd \
-    --hash=sha256:e2ef7239991699e3355d54f8e968a21bb940a1dbf34a4d226741e64462516fad
+wheel==0.37.1 \
+    --hash=sha256:4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a \
+    --hash=sha256:e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4
     # via astunparse
 zipp==3.6.0 \
     --hash=sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832 \


### PR DESCRIPTION
This is an updated version of #505 with the rename (cohort-extractor v2 -> databuilder) included, the page removed from the ToC, updated contract module links, and a justfile command to extract the docs JSON from databuilder itself.

The references in backend-contracts.md are representative and will be broken out into the relevant files and updated for the ticket once #588 is merged, they currently look like this:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/7KuqlRb5/ab7a7fa5-e91e-4423-9de3-a9dd9d521186.jpg?v=0155d086f3f8b534f8fd16f73c6c250c)