### PR TITLE
Document background to OpenSAFELY Contracts

### DIFF
--- a/docs/backend-implementer-integration.md
+++ b/docs/backend-implementer-integration.md
@@ -1,0 +1,87 @@
+# Guidance for data backend implementers integrating into OpenSAFELY
+
+---8<-- 'includes/data-builder-danger-header.md'
+
+!!! warning
+
+    This page is not yet complete.
+
+    More complete guides on working with OpenSAFELY Contracts for
+    external data providers will eventually be documented more fully here.
+
+## Introduction
+
+For a backend implementer to offer new data for OpenSAFELY, there are
+two technical requirements:
+
+1. The data being offered must satisfy [OpenSAFELY
+   Contracts](contracts-intro.md).
+2. The backend must have an [implementation in OpenSAFELY Data
+   Builder](data-builder-intro.md).
+
+## Implementing existing OpenSAFELY Contracts
+
+The existing [Contracts reference](contracts-reference.md) provides data
+specifications for both OpenSAFELY users and backend implementers.
+
+An OpenSAFELY backend implements one or more of these specifications.
+Each specification pertains to a specific health care data domain.
+
+For each data column in a Contract, the Contract details:
+
+* column name
+* data description
+* data type
+* any constraints
+
+Refer to those specifications when preparing data tables for integration
+with OpenSAFELY.
+
+### What if provided data does not exactly match the relevant Contract?
+
+Structuring data in line with OpenSAFELY Contracts makes it easier for
+researchers using OpenSAFELY to run studies across multiple data
+backends. However, there may be administrative or technical reasons why
+backend implementers cannot satisfy a Contract precisely.
+
+Some deviation from the Contract is permitted.
+
+TODO: What needs to be done if there is deviation? Is this following
+discussion and approval by OpenSAFELY?
+
+TODO: What counts as permitted deviation and what counts as a breach of
+the Contract?
+
+## Proposing new OpenSAFELY Contracts
+
+!!! note
+
+    OpenSAFELY Contracts are still in an initial design and
+    implementation phase. We already have designs for additional
+    Contracts that will be implemented in future.
+
+If no existing Contract corresponds to a healthcare data domain that you
+wish to offer, [please email our technical team to
+discuss](mailto:tech@opensafely.org). This may involve the creation of a
+new [Custom Contract](contracts-intro.md#common-and-custom-contracts).
+
+## Integrating a data backend into OpenSAFELY Data Builder
+
+[OpenSAFELY Data Builder](data-builder-intro.md) is the software
+component that researchers use to extract datasets of interest from
+healthcare data providers in OpenSAFELY. Data Builder is a Python
+application.
+
+Data Builder abstracts the details of writing queries for researchers
+away. Researchers only need be concerned with specifying the data they
+want, not how to access it.
+
+If you are a new backend implementer, [please email our technical team
+to discuss Data Builder integration](mailto:tech@opensafely.org).
+
+!!! note
+
+    [Existing backend query implementations](https://github.com/opensafely-core/databuilder/tree/main/databuilder/backends)
+    are in Data Builder's GitHub repository.
+
+---8<-- 'includes/glossary.md'

--- a/docs/contracts-intro.md
+++ b/docs/contracts-intro.md
@@ -2,11 +2,181 @@
 
 ---8<-- 'includes/data-builder-danger-header.md'
 
-This page will introduce OpenSAFELY Contracts, explaining:
+## OpenSAFELY Contracts are a clinical data specification
 
-* what they are
-* the process by which new contracts could be proposed
-* where [details of existing contracts will be
-  found](contracts-reference.md)
+*OpenSAFELY Contracts* are an important OpenSAFELY concept that is
+introduced with Data Builder.
+
+This page describes:
+
+* what OpenSAFELY Contracts are
+* how OpenSAFELY Contracts relate to dataset definitions
+
+Each OpenSAFELY Contract is a formal specification, [described in
+code](https://github.com/opensafely-core/databuilder/blob/main/databuilder/contracts/contracts.py),
+relating to a particular clinical data domain. OpenSAFELY Contracts are
+authored by the OpenSAFELY platform developers: the Contract designs are
+informed by discussion and feedback from data providers and researchers.
+
+Researchers write dataset definitions to access data tables from
+OpenSAFELY backends. All available data tables within OpenSAFELY satisfy
+an OpenSAFELY Contract, regardless of which data provider operates the
+backend.
+
+TODO: does a table only satisfy one contract, or possibly multiple?
+
+## The OpenSAFELY Contracts reference
+
+The [OpenSAFELY Contracts reference](contracts-reference.md) has full
+details of each individual Contract. When writing a dataset definition,
+researchers should consult [the OpenSAFELY Contracts
+reference](contracts-reference.md) to see:
+
+* the data available in OpenSAFELY backends
+* how the data is structured
+* what that data represents
+
+!!! warning
+    OpenSAFELY Contracts apply only when accessing OpenSAFELY data using
+    *dataset definitions*, written to run with Data Builder. Contracts
+    do not apply to *study definitions* written for the existing cohort
+    extractor.
+
+## The goals of OpenSAFELY Contracts
+
+Contracts make it easier for:
+
+* *Researchers* to understand what data is available in
+  OpenSAFELY and how that data is represented.
+* *Data providers* to structure their data for OpenSAFELY.
+* *OpenSAFELY's developers* to extend OpenSAFELY to additional
+  healthcare and clinical data domains in future.
+
+!!! note
+    OpenSAFELY Contracts are a new concept still being explored.
+
+    We [value
+    feedback](https://github.com/opensafely/documentation/discussions)
+    from both OpenSAFELY users and data providers, and conversations on
+    how we might further refine the design of individual OpenSAFELY
+    Contracts or the system as a whole.
+
+### The benefits of OpenSAFELY Contracts for researchers
+
+With OpenSAFELY Contracts, researchers benefit from:
+
+* Guarantees on the structure of the data table being queried.
+* A simpler query interface to multiple backends with the ability to:
+    * look up which backends provide the data of interest
+    * verify which backends are compatible with their dataset definitions
+    * run data definitions on multiple different backends, without
+      having to write specific code for each individual backend
+* More consistent documentation that:
+    * describes the commonalities of the data offered by different backends
+    * notes where individual backends provide data that deviates from others
+
+## Common and Custom Contracts
+
+Data backends that are accessible via OpenSAFELY provide data tables. Each
+data table satisfies an OpenSAFELY Contract.
+
+There are two types of Contracts:
+
+* **Common Contracts**, required by all OpenSAFELY backends and covering
+  core clinical data domains
+* **Custom Contracts**, offered by just some backends and covering more
+  specialised clinical data domains
+
+Both the structure of the Contracts and the method of accessing
+associated tables is the same for both Common and Core Contracts.
+
+### Common Contracts
+
+All OpenSAFELY backends satisfy Common Contracts.
+
+There will be several different Common Contracts available with the
+initial release of Data Builder. More Common Contracts may be added in
+future.
+
+!!! warning
+    Some backends might deviate slightly from the suggested OpenSAFELY
+    behaviour shared by most backends. Refer to the [OpenSAFELY
+    Contracts Reference](contracts-reference.md) for backends you intend
+    to access with your dataset definition.
+
+For dataset definitions that only access tables defined by Common
+Contracts, those dataset definitions should be largely compatible with all
+OpenSAFELY backends.
+
+### Custom Contracts
+
+Some backends may offer particularly specialised data that is not yet
+covered by a Common Contract. *Custom Contracts* allow individual
+backends to still offer this data via OpenSAFELY.
+
+!!! warning
+    Using Custom Contracts might tie a dataset definition more closely
+    to a specific backend, than if just Common Contracts are used. This
+    also depends on how the dataset definition is designed.
+
+!!! note
+    Should additional data providers want to offer data that closely resembles
+    an existing *Custom* Contract, OpenSAFELY developers would consider a new
+    *Common* Contract.
+
+## Reading an OpenSAFELY Contract
+
+!!! note
+    Refer to the [OpenSAFELY Contracts
+    Reference](contracts-intro#the-opensafely-contracts-reference) for
+    the details of specific contracts.
+
+Each OpenSAFELY Contract relates to a specific domain of health record
+data. The name of the Contract indicates the data domain covered by the
+Contract. Tables that satisfy these Contracts can be accessed in a
+dataset definition via [Data Builder's query language,
+ehrQL](ehrql-intro.md).
+
+An OpenSAFELY Contract provides the following information:
+
+* the **variable names**. Each variable is denoted by the
+  identifier you use to access the variable in ehrQL.
+* the **variable's description**. The description summarises what the
+  variable represents.
+* the **variable's data type**. For instance, a variable
+  might be one of the following:
+    * integer type
+    * floating point type
+    * date type
+    * string type
+    * or some other type not in this list
+* the **additional constraints on the variable's data values**, other
+  than those given by the variable's type. For instance,
+    * the variable might be of date type, but all values are the first
+      of the month
+    * the variable might be of integer type, but all values are positive
+      integers
+
+## Miscellaneous TODOs
+
+* TODO: Should we refer to columns or variables?
+* TODO: Finalise details above based on what we actually display. Do we
+  know all the variable types, or can we link to them?
+* TODO: Do we want to have nulls as a constraint or as a separate
+  column in the reference?
+* TODO: How are deviations noted in the reference? Is this via a note
+  within the same contract? Or are we going to document the same
+  contract multiple times for different providers.
+* TODO: Where do we document about how to validate which backends run a
+  definition?
+* TODO: Do we need anything on Contract versioning right now? How does
+  versioning work?
+
+## For backend data providers
+
+* TODO: Does content for backend providers go here or another page?
+* TODO: What is the process by which new contracts could be proposed?
+* TODO: Where do we describe the integration process for
+  data providers?
 
 ---8<-- 'includes/glossary.md'

--- a/docs/contracts-intro.md
+++ b/docs/contracts-intro.md
@@ -4,47 +4,52 @@
 
 ## OpenSAFELY Contracts are a clinical data specification
 
-*OpenSAFELY Contracts* are an important OpenSAFELY concept that is
-introduced with Data Builder.
+An *OpenSAFELY Contract* is a core concept in the OpenSAFELY framework.
+Anyone using Data Builder should familiarise themselves with how
+Contracts work.
 
 This page describes:
 
 * what OpenSAFELY Contracts are
 * how OpenSAFELY Contracts relate to dataset definitions
 
-Each OpenSAFELY Contract is a formal specification — [described in
-code](https://github.com/opensafely-core/databuilder/blob/main/databuilder/contracts/)
-— relating to a particular clinical data domain.
+Each OpenSAFELY Contract is a formal specification relating to a
+particular clinical data domain.
+
+!!! note
+    For researchers, the human-readable version of each Contract is
+    listed in the [Contracts reference](contracts-reference.md).
+
+    For developers working on OpenSAFELY integrations, you can also see
+    how [each Contract is specified in Python
+    code](https://github.com/opensafely-core/databuilder/blob/main/databuilder/contracts/).
+    **It is not necessary to understand the Contract's Python code to be
+    able to use a Contract.**
 
 OpenSAFELY Contracts are authored by the OpenSAFELY platform developers:
 the Contract designs are informed by discussion and feedback from [data
 providers](data-provider-integration.md) and researchers.
 
-Researchers write dataset definitions to access data tables from
-OpenSAFELY backends. All of the data tables available from OpenSAFELY
-satisfy a single OpenSAFELY Contract, regardless of which data provider
-operates the backend.
+### How do OpenSAFELY Contracts fit into OpenSAFELY?
 
-## The OpenSAFELY Contracts reference
+Researchers write [dataset definitions](dataset-definition.md) to access
+data tables from OpenSAFELY backends. This is a simple example of a
+dataset definition that accesses a data table:
 
-The [OpenSAFELY Contracts reference](contracts-reference.md) has full
-details of each individual Contract. When writing a dataset definition,
-researchers should consult [the OpenSAFELY Contracts
-reference](contracts-reference.md) to see:
+---8<-- 'examples/src-minimal-ehrql.md'
 
-* what data is available in OpenSAFELY backends
-* how the data is structured
-* what that data represents and how it should be interpreted
+Dataset definitions are run using OpenSAFELY Data Builder. When running
+the dataset definition against live backends on the OpenSAFELY platform,
+the data requested will then be extracted.
 
-!!! warning
-    OpenSAFELY Contracts apply only when accessing OpenSAFELY data using
-    *dataset definitions*, written to run with Data Builder. Contracts
-    do not apply to legacy [*study definitions*](study-def.md) written for
-    cohort-extractor.
+!!! note
+    The dataset definition is provided as an example only here.
+    You do not need to understand how to write a dataset definition
+    to follow the rest of this page.
 
-!!! warning
-    The OpenSAFELY Contracts are still in development and subject to
-    frequent change.
+**Data tables in OpenSAFELY backends must relate to an OpenSAFELY
+Contract.** Researchers then have guarantees that data from different
+data providers can be accessed and interpreted in a consistent way.
 
 ## The goals of OpenSAFELY Contracts
 
@@ -53,12 +58,12 @@ Contracts make it easier for:
 * *Researchers* to understand what data is available in
   OpenSAFELY and how that data is represented.
 * *Data providers* to structure their data for OpenSAFELY and
-  auto-generated documentation for their service.
+  auto-generate documentation for their service.
 * *OpenSAFELY's developers* to extend OpenSAFELY to additional
   healthcare and clinical data domains in future.
 
 !!! note
-    OpenSAFELY Contracts are a new concept still being explored.
+    OpenSAFELY Contracts are still a new concept under exploration.
 
     We [value
     feedback](https://github.com/opensafely/documentation/discussions)
@@ -87,13 +92,11 @@ that can be referenced in *dataset definitions*. Each data table
 accessible via OpenSAFELY satisfies an OpenSAFELY Contract.
 
 Each data backend in OpenSAFELY can choose which of those Contracts to
-satisfy. The goal is that multiple backends offer data in the same
-structured way to researchers.
+satisfy.
 
 !!! note
-    Refer to the [available OpenSAFELY data backends
-    details](data-backends.md) to see which backends implement which
-    contracts.
+    Refer to the [available OpenSAFELY data backends](data-backends.md)
+    to see which backends implement which Contracts.
 
 All Contracts share the:
 
@@ -122,18 +125,37 @@ covered by any Contract. In these cases, a new Contract would be added.
     decided.
 
     One possibility being discussed is via [hierarchical
-    naming](#the-scope-of-opensafely-contracts), with a level in the
+    naming](#names-of-contracts), with levels in the
     hierarchy indicating:
 
     * that the Contract is used by a single backend only
-    * and/or indicating the organisation providing that Contract
+    * and/or the organisation providing that Contract
 
 ## Reading an OpenSAFELY Contract
 
-!!! note
-    Refer to the [OpenSAFELY Contracts
-    Reference](contracts-intro.md#the-opensafely-contracts-reference) for
-    the details of specific contracts.
+### The OpenSAFELY Contracts reference
+
+The [OpenSAFELY Contracts reference](contracts-reference.md) has full
+details of each individual Contract. When writing a dataset definition,
+researchers should consult [the OpenSAFELY Contracts
+reference](contracts-reference.md) to see:
+
+* the data offered by each OpenSAFELY backend
+* how that data is structured
+* what that data represents
+* how that data should be interpreted
+
+!!! warning
+    The use of OpenSAFELY Contracts applies only when writing *dataset definitions* for Data Builder.
+
+    Contracts do not apply to [*study definitions*](study-def.md) written for
+    our legacy cohort-extractor.
+
+!!! warning
+    OpenSAFELY Contracts are still in development and subject to
+    frequent change.
+
+### The structure of a Contract
 
 Each OpenSAFELY Contract relates to a specific domain of health record
 data. The name of the Contract indicates the data domain covered by the
@@ -154,7 +176,7 @@ associated table:
     * floating point type
     * date type
     * string type
-    * or some other type not in this list
+    * some other type not in this list
 * the **additional constraints on the column's data values**, other than
   those given by the column's type. For instance,
     * the column might be of date type, but all values are the first of

--- a/docs/contracts-intro.md
+++ b/docs/contracts-intro.md
@@ -80,36 +80,30 @@ With OpenSAFELY Contracts, researchers benefit from:
     * describes the commonalities of the data offered by different backends
     * notes where individual backends provide data that deviates from others
 
-## Common and Custom Contracts
+## How Contracts work
 
 Data backends that are accessible via OpenSAFELY provide *data tables*
 that can be referenced in *dataset definitions*. Each data table
 accessible via OpenSAFELY satisfies an OpenSAFELY Contract.
 
-There are two types of Contract:
-
-* **Common Contracts** describe data *shared across multiple different
-  OpenSAFELY backends*.
-* **Custom Contracts** describe data *unique to one particular backend*.
-
 Each data backend in OpenSAFELY can choose which of those Contracts to
-satisfy.
+satisfy. The goal is that multiple backends offer data in the same
+structured way to researchers.
 
 !!! note
     Refer to the [available OpenSAFELY data backends
     details](data-backends.md) to see which backends implement which
     contracts.
 
-All Contracts, Common and Custom, share the:
+All Contracts share the:
 
 * same Contract structure, made up of details about data columns
 * same way of accessing associated tables in Data Builder via ehrQL
 
-### Common Contracts
+### Existing Contracts
 
-There will be several different Common Contracts available with the
-initial release of Data Builder. More Common Contracts will be added in
-future.
+There will be several different Contracts available with the initial
+release of Data Builder. More Contracts will be added in future.
 
 !!! warning
     Some backends might deviate slightly from the suggested OpenSAFELY
@@ -117,28 +111,22 @@ future.
     Contracts Reference](contracts-reference.md) for backends you intend
     to access with your dataset definition.
 
-### Custom Contracts
+### More specialised Contracts
 
-Some backends may offer additional data that is not yet
-covered by the related Common Contract, or specialised data that is not covered
-by any Common Contract.
-
-*Custom Contracts* allow individual backends to:
-
-* offer such specialised data in a structured way via OpenSAFELY
-* extend the data offered in a Common Contract, adding, for example,
-  extra columns
+Some backends may offer additional data that is not yet covered by the
+related Contract. Some backends may even offer specialised data not yet
+covered by any Contract. In these cases, a new Contract would be added.
 
 !!! warning
-    Accessing data from a Custom Contract may tie a dataset definition
-    more closely to a specific backend, than if just Common Contracts
-    are used. This may also depend on how the dataset definition is
-    designed.
+    How these more specialised Contracts are labelled is to be fully
+    decided.
 
-!!! note
-    If multiple data providers want to offer data that closely resembles
-    an existing *Custom* Contract, OpenSAFELY developers would consider adding
-    a new *Common* Contract.
+    One possibility being discussed is via [hierarchical
+    naming](#the-scope-of-opensafely-contracts), with a level in the
+    hierarchy indicating:
+
+    * that the Contract is used by a single backend only
+    * and/or indicating the organisation providing that Contract
 
 ## Reading an OpenSAFELY Contract
 
@@ -182,7 +170,7 @@ associated table:
     In future, we aim to automatically validate these constraints. Once
     implemented, this will guarantee the constraints are always true.
 
-### The scope of OpenSAFELY Contracts
+## The scope of OpenSAFELY Contracts
 
 !!! warning
     The currently implemented Contracts are scoped to NHS England data.
@@ -192,26 +180,32 @@ associated table:
     Future Contracts may cover data from other organisations and
     geographic regions.
 
-!!! note
-    This note is provided only as information on the possible
-    development direction of Contracts.
+## Names of Contracts
 
-    Contracts will eventually use a hierarchical naming system to avoid
-    name clashes. Multiple Common Contracts may exist that refer to a
-    similar data topic, but the data in each Contract has a different
-    structure.
+!!! note
+    Contracts are likely to eventually use a hierarchical naming system
+    to:
+
+    * indicate what domain, organisation and geography the Contract
+      relates to
+    * avoid name clashes
+
+    Multiple Contracts may therefore exist that refer to a similar data
+    topic, but the data in each Contract has a different structure.
 
     As a specific example, the current `WIP_PatientAddress` Contract may
     eventually be in a hierarchy such as `UK/NHSE/PatientAddress`. This
-    distinguishes the `PatientAddress` Contract for NHS England, from
+    distinguishes the `PatientAddress` Contract for NHS England, from a
     `PatientAddress` as used by another healthcare organisation, perhaps
-    in another country.
+    in another country, where that data may have considerably different
+    attributes.
 
-### Versioning
+## Versioning
 
 !!! warning
     The initial available batch of OpenSAFELY Contracts do not yet
-    implement versioning and are subject to change.
+    implement versioning. These Contracts are currently subject to
+    change.
 
 !!! note
     This note is provided only as information on the possible

--- a/docs/contracts-intro.md
+++ b/docs/contracts-intro.md
@@ -12,18 +12,18 @@ This page describes:
 * what OpenSAFELY Contracts are
 * how OpenSAFELY Contracts relate to dataset definitions
 
-Each OpenSAFELY Contract is a formal specification, [described in
-code](https://github.com/opensafely-core/databuilder/blob/main/databuilder/contracts/contracts.py),
-relating to a particular clinical data domain. OpenSAFELY Contracts are
-authored by the OpenSAFELY platform developers: the Contract designs are
-informed by discussion and feedback from data providers and researchers.
+Each OpenSAFELY Contract is a formal specification — [described in
+code](https://github.com/opensafely-core/databuilder/blob/main/databuilder/contracts/)
+— relating to a particular clinical data domain.
+
+OpenSAFELY Contracts are authored by the OpenSAFELY platform developers:
+the Contract designs are informed by discussion and feedback from [data
+providers](backend-implementer-integration.md) and researchers.
 
 Researchers write dataset definitions to access data tables from
-OpenSAFELY backends. All available data tables within OpenSAFELY satisfy
-an OpenSAFELY Contract, regardless of which data provider operates the
-backend.
-
-TODO: does a table only satisfy one contract, or possibly multiple?
+OpenSAFELY backends. All of the data tables available from OpenSAFELY
+satisfy a single OpenSAFELY Contract, regardless of which data provider
+operates the backend.
 
 ## The OpenSAFELY Contracts reference
 
@@ -32,15 +32,19 @@ details of each individual Contract. When writing a dataset definition,
 researchers should consult [the OpenSAFELY Contracts
 reference](contracts-reference.md) to see:
 
-* the data available in OpenSAFELY backends
+* what data is available in OpenSAFELY backends
 * how the data is structured
 * what that data represents
 
 !!! warning
     OpenSAFELY Contracts apply only when accessing OpenSAFELY data using
     *dataset definitions*, written to run with Data Builder. Contracts
-    do not apply to *study definitions* written for the existing cohort
-    extractor.
+    do not apply to [*study definitions*](study-def.md) written for
+    cohort-extractor.
+
+!!! warning
+    The OpenSAFELY Contracts are still in development and subject to
+    frequent change.
 
 ## The goals of OpenSAFELY Contracts
 
@@ -48,7 +52,8 @@ Contracts make it easier for:
 
 * *Researchers* to understand what data is available in
   OpenSAFELY and how that data is represented.
-* *Data providers* to structure their data for OpenSAFELY.
+* *Data providers* to structure their data for OpenSAFELY and
+  auto-generated documentation for their service.
 * *OpenSAFELY's developers* to extend OpenSAFELY to additional
   healthcare and clinical data domains in future.
 
@@ -78,24 +83,31 @@ With OpenSAFELY Contracts, researchers benefit from:
 ## Common and Custom Contracts
 
 Data backends that are accessible via OpenSAFELY provide data tables. Each
-data table satisfies an OpenSAFELY Contract.
+data table accessible via OpenSAFELY satisfies an OpenSAFELY Contract.
 
-There are two types of Contracts:
+There are two types of Contract:
 
-* **Common Contracts**, required by all OpenSAFELY backends and covering
-  core clinical data domains
-* **Custom Contracts**, offered by just some backends and covering more
-  specialised clinical data domains
+* **Common Contracts** describe data *shared across multiple different
+  OpenSAFELY backends*.
+* **Custom Contracts** describe data *unique to one particular backend*.
 
-Both the structure of the Contracts and the method of accessing
-associated tables is the same for both Common and Core Contracts.
+Each data backend in OpenSAFELY can choose which of those Contracts to
+satisfy.
+
+!!! note
+    Refer to the [available OpenSAFELY data backends
+    details](data-backends.md) to see which backends implement which
+    contracts.
+
+All Contracts, Common and Custom, share the:
+
+* same Contract structure, made up of details about data columns
+* same way of accessing associated tables in Data Builder via ehrQL
 
 ### Common Contracts
 
-All OpenSAFELY backends satisfy Common Contracts.
-
 There will be several different Common Contracts available with the
-initial release of Data Builder. More Common Contracts may be added in
+initial release of Data Builder. More Common Contracts will be added in
 future.
 
 !!! warning
@@ -104,31 +116,34 @@ future.
     Contracts Reference](contracts-reference.md) for backends you intend
     to access with your dataset definition.
 
-For dataset definitions that only access tables defined by Common
-Contracts, those dataset definitions should be largely compatible with all
-OpenSAFELY backends.
-
 ### Custom Contracts
 
-Some backends may offer particularly specialised data that is not yet
-covered by a Common Contract. *Custom Contracts* allow individual
-backends to still offer this data via OpenSAFELY.
+Some backends may offer additional data that is not yet
+covered by the related Common Contract, or specialised data that is not covered
+by any Common Contract.
+
+*Custom Contracts* allow individual backends to:
+
+* offer such specialised data in a structured way via OpenSAFELY
+* extend the data offered in a Common Contract, adding, for example,
+  extra columns
 
 !!! warning
-    Using Custom Contracts might tie a dataset definition more closely
-    to a specific backend, than if just Common Contracts are used. This
-    also depends on how the dataset definition is designed.
+    Accessing data from a Custom Contract may tie a dataset definition
+    more closely to a specific backend, than if just Common Contracts
+    are used. This may also depend on how the dataset definition is
+    designed.
 
 !!! note
-    Should additional data providers want to offer data that closely resembles
-    an existing *Custom* Contract, OpenSAFELY developers would consider a new
-    *Common* Contract.
+    If multiple data providers want to offer data that closely resembles
+    an existing *Custom* Contract, OpenSAFELY developers would consider adding
+    a new *Common* Contract.
 
 ## Reading an OpenSAFELY Contract
 
 !!! note
     Refer to the [OpenSAFELY Contracts
-    Reference](contracts-intro#the-opensafely-contracts-reference) for
+    Reference](contracts-intro.md#the-opensafely-contracts-reference) for
     the details of specific contracts.
 
 Each OpenSAFELY Contract relates to a specific domain of health record
@@ -137,46 +152,78 @@ Contract. Tables that satisfy these Contracts can be accessed in a
 dataset definition via [Data Builder's query language,
 ehrQL](ehrql-intro.md).
 
-An OpenSAFELY Contract provides the following information:
+An OpenSAFELY Contract provides the following information for each
+associated table:
 
-* the **variable names**. Each variable is denoted by the
-  identifier you use to access the variable in ehrQL.
-* the **variable's description**. The description summarises what the
-  variable represents.
-* the **variable's data type**. For instance, a variable
-  might be one of the following:
+* the **column names**. Each column is denoted by the identifier you use
+  to access it in ehrQL.
+* the **column's description**. The description summarises what the
+  column represents.
+* the **column's data type**. For instance, a column's data type might
+  be one of the following:
     * integer type
     * floating point type
     * date type
     * string type
     * or some other type not in this list
-* the **additional constraints on the variable's data values**, other
-  than those given by the variable's type. For instance,
-    * the variable might be of date type, but all values are the first
-      of the month
-    * the variable might be of integer type, but all values are positive
+* the **additional constraints on the column's data values**, other than
+  those given by the column's type. For instance,
+    * the column might be of date type, but all values are the first of
+      the month
+    * the column might be of integer type, but all values are positive
       integers
 
-## Miscellaneous TODOs
+!!! warning
+    Any additional constraints are currently provided as guidance only.
+    The constraints may be true, but are *not yet automatically verified
+    against the data provided by OpenSAFELY backends*.
 
-* TODO: Should we refer to columns or variables?
-* TODO: Finalise details above based on what we actually display. Do we
-  know all the variable types, or can we link to them?
-* TODO: Do we want to have nulls as a constraint or as a separate
-  column in the reference?
-* TODO: How are deviations noted in the reference? Is this via a note
-  within the same contract? Or are we going to document the same
-  contract multiple times for different providers.
-* TODO: Where do we document about how to validate which backends run a
-  definition?
-* TODO: Do we need anything on Contract versioning right now? How does
-  versioning work?
+    In future, we aim to automatically validate these constraints. Once
+    implemented, this will guarantee the constraints are always true.
 
-## For backend data providers
+### The scope of OpenSAFELY Contracts
 
-* TODO: Does content for backend providers go here or another page?
-* TODO: What is the process by which new contracts could be proposed?
-* TODO: Where do we describe the integration process for
-  data providers?
+!!! warning
+    The currently implemented Contracts are scoped to NHS England data.
+    These Contracts are designed for use for **populations registered at
+    GP practices in England**.
+
+    Future Contracts may cover data from other organisations and
+    geographic regions.
+
+!!! note
+    This note is provided only as information on the possible
+    development direction of Contracts.
+
+    Contracts will eventually use a hierarchical naming system to avoid
+    name clashes. Multiple Common Contracts may exist that refer to a
+    similar data topic, but the data in each Contract has a different
+    structure.
+
+    As a specific example, the current `WIP_PatientAddress` Contract may
+    eventually be in a hierarchy such as `UK/NHSE/PatientAddress`. This
+    distinguishes the `PatientAddress` Contract for NHS England, from
+    `PatientAddress` as used by another healthcare organisation, perhaps
+    in another country.
+
+### Versioning
+
+!!! warning
+    The initial available batch of OpenSAFELY Contracts do not yet
+    implement versioning and are subject to change.
+
+!!! note
+    This note is provided only as information on the possible
+    development direction of Contracts.
+
+    The intent is for each Contract to eventually be assigned a [semantic-style
+    version number](https://semver.org).
+
+    For instance, you might choose to use version `v1.0.0` of a Contract
+    such as `UK/NHSE/PatientAddress`.
+
+    Versioning will allow the designs of each Contract to be modified,
+    improved and extended, while offering backwards compatibility and
+    stability for researchers and data providers.
 
 ---8<-- 'includes/glossary.md'

--- a/docs/contracts-intro.md
+++ b/docs/contracts-intro.md
@@ -33,10 +33,10 @@ providers](data-provider-integration.md) and researchers.
 ### How do OpenSAFELY Contracts fit into OpenSAFELY?
 
 Researchers write [dataset definitions](dataset-definition.md) to access
-data tables from OpenSAFELY backends. This is a simple example of a
-dataset definition that accesses a data table:
+data tables from OpenSAFELY backends. This minimal example code
+accesses the `date_of_birth` column in the `patients` data table:
 
----8<-- 'examples/src-minimal-ehrql.md'
+---8<-- 'examples/src-minimal-ehrql-import-patients.md'
 
 Dataset definitions are run using OpenSAFELY Data Builder. When running
 the dataset definition against live backends on the OpenSAFELY platform,
@@ -47,7 +47,7 @@ the data requested will then be extracted.
     You do not need to understand how to write a dataset definition
     to follow the rest of this page.
 
-**Data tables in OpenSAFELY backends must relate to an OpenSAFELY
+**Data tables in OpenSAFELY backends are always related to an OpenSAFELY
 Contract.** Researchers then have guarantees that data from different
 data providers can be accessed and interpreted in a consistent way.
 
@@ -91,17 +91,17 @@ Data backends that are accessible via OpenSAFELY provide *data tables*
 that can be referenced in *dataset definitions*. Each data table
 accessible via OpenSAFELY satisfies an OpenSAFELY Contract.
 
-Each data backend in OpenSAFELY can choose which of those Contracts to
-satisfy.
+Data providers can make data available to OpenSAFELY by choosing the Contracts
+that their backends will satisfy.
 
 !!! note
     Refer to the [available OpenSAFELY data backends](data-backends.md)
     to see which backends implement which Contracts.
 
-All Contracts share the:
+All Contracts share the same:
 
-* same Contract structure, made up of details about data columns
-* same way of accessing associated tables in Data Builder via ehrQL
+* Contract structure, made up of details about data columns
+* way of accessing associated tables in Data Builder via ehrQL
 
 ### Existing Contracts
 

--- a/docs/contracts-intro.md
+++ b/docs/contracts-intro.md
@@ -18,7 +18,7 @@ code](https://github.com/opensafely-core/databuilder/blob/main/databuilder/contr
 
 OpenSAFELY Contracts are authored by the OpenSAFELY platform developers:
 the Contract designs are informed by discussion and feedback from [data
-providers](backend-implementer-integration.md) and researchers.
+providers](data-provider-integration.md) and researchers.
 
 Researchers write dataset definitions to access data tables from
 OpenSAFELY backends. All of the data tables available from OpenSAFELY
@@ -34,12 +34,12 @@ reference](contracts-reference.md) to see:
 
 * what data is available in OpenSAFELY backends
 * how the data is structured
-* what that data represents
+* what that data represents and how it should be interpreted
 
 !!! warning
     OpenSAFELY Contracts apply only when accessing OpenSAFELY data using
     *dataset definitions*, written to run with Data Builder. Contracts
-    do not apply to [*study definitions*](study-def.md) written for
+    do not apply to legacy [*study definitions*](study-def.md) written for
     cohort-extractor.
 
 !!! warning
@@ -82,8 +82,9 @@ With OpenSAFELY Contracts, researchers benefit from:
 
 ## Common and Custom Contracts
 
-Data backends that are accessible via OpenSAFELY provide data tables. Each
-data table accessible via OpenSAFELY satisfies an OpenSAFELY Contract.
+Data backends that are accessible via OpenSAFELY provide *data tables*
+that can be referenced in *dataset definitions*. Each data table
+accessible via OpenSAFELY satisfies an OpenSAFELY Contract.
 
 There are two types of Contract:
 

--- a/docs/data-builder-toc.md
+++ b/docs/data-builder-toc.md
@@ -32,3 +32,4 @@
 * [OpenSAFELY Contracts introduction](contracts-intro.md)
 * [OpenSAFELY Contracts reference](contracts-reference.md)
 * [OpenSAFELY data backends](data-backends.md)
+* [Guidance for data backend implementers integrating into OpenSAFELY](backend-implementer-integration.md)

--- a/docs/data-builder-toc.md
+++ b/docs/data-builder-toc.md
@@ -32,4 +32,4 @@
 * [OpenSAFELY Contracts introduction](contracts-intro.md)
 * [OpenSAFELY Contracts reference](contracts-reference.md)
 * [OpenSAFELY data backends](data-backends.md)
-* [Guidance for data backend implementers integrating into OpenSAFELY](backend-implementer-integration.md)
+* [Guidance for data providers integrating into OpenSAFELY](data-provider-integration.md)

--- a/docs/data-provider-integration.md
+++ b/docs/data-provider-integration.md
@@ -21,18 +21,14 @@ technical requirements:
 
 ## Implementing existing OpenSAFELY Contracts
 
-The existing [Contracts reference](contracts-reference.md) provides data
-specifications for both OpenSAFELY users and data providers.
-
 An OpenSAFELY backend implements one or more of these specifications.
 Each specification covers a specific healthcare data domain.
 
-For each data column in a Contract, the Contract details:
+The structure of a Contract is explained in the [Contracts
+introduction](contracts-intro.md#the-structure-of-a-contract).
 
-* column name
-* data description
-* data type
-* any constraints
+The [Contracts reference](contracts-reference.md) provides the existing
+data specifications for both OpenSAFELY users and data providers.
 
 Refer to those specifications when preparing data tables for integration
 with OpenSAFELY.

--- a/docs/data-provider-integration.md
+++ b/docs/data-provider-integration.md
@@ -1,4 +1,4 @@
-# Guidance for data backend implementers integrating into OpenSAFELY
+# Guidance for data providers integrating into OpenSAFELY
 
 ---8<-- 'includes/data-builder-danger-header.md'
 
@@ -11,21 +11,21 @@
 
 ## Introduction
 
-For a backend implementer to offer new data for OpenSAFELY, there are
-two technical requirements:
+For a data provider to offer new data for OpenSAFELY, there are two
+technical requirements:
 
 1. The data being offered must satisfy [OpenSAFELY
    Contracts](contracts-intro.md).
-2. The backend must have an [implementation in OpenSAFELY Data
+2. The data backend must have an [implementation in OpenSAFELY Data
    Builder](data-builder-intro.md).
 
 ## Implementing existing OpenSAFELY Contracts
 
 The existing [Contracts reference](contracts-reference.md) provides data
-specifications for both OpenSAFELY users and backend implementers.
+specifications for both OpenSAFELY users and data providers.
 
 An OpenSAFELY backend implements one or more of these specifications.
-Each specification pertains to a specific health care data domain.
+Each specification covers a specific health care data domain.
 
 For each data column in a Contract, the Contract details:
 
@@ -42,7 +42,7 @@ with OpenSAFELY.
 Structuring data in line with OpenSAFELY Contracts makes it easier for
 researchers using OpenSAFELY to run studies across multiple data
 backends. However, there may be administrative or technical reasons why
-backend implementers cannot satisfy a Contract precisely.
+data providers cannot satisfy a Contract precisely.
 
 Some deviation from the Contract is permitted.
 
@@ -69,19 +69,35 @@ new [Custom Contract](contracts-intro.md#common-and-custom-contracts).
 
 [OpenSAFELY Data Builder](data-builder-intro.md) is the software
 component that researchers use to extract datasets of interest from
-healthcare data providers in OpenSAFELY. Data Builder is a Python
-application.
+healthcare data providers in OpenSAFELY. Data Builder is written in
+Python.
 
 Data Builder abstracts the details of writing queries for researchers
 away. Researchers only need be concerned with specifying the data they
 want, not how to access it.
 
-If you are a new backend implementer, [please email our technical team
-to discuss Data Builder integration](mailto:tech@opensafely.org).
+### Data Builder integration requirements
+
+Supporting a new backend in Data Builder has two requirements:
+
+1. Data Builder must have a [query
+   engine](https://github.com/opensafely-core/databuilder/tree/main/databuilder/query_engines)
+   compatible with the backend.
+2. Data Builder must have code [describing how tables in the backend
+   satisfy the supported OpenSAFELY
+   Contracts](https://github.com/opensafely-core/databuilder/tree/main/databuilder/backends).
 
 !!! note
+    Currently, Data Builder has the following query engines:
 
-    [Existing backend query implementations](https://github.com/opensafely-core/databuilder/tree/main/databuilder/backends)
-    are in Data Builder's GitHub repository.
+    * Microsoft SQL Server
+    * Apache Spark.
+
+    Support for another data store will require adding a new query
+    engine.
+
+If you are a new data provider, [please contact our technical team to
+discuss integration with Data Builder and
+OpenSAFELY](how-to-get-help.md#data-providers).
 
 ---8<-- 'includes/glossary.md'

--- a/docs/data-provider-integration.md
+++ b/docs/data-provider-integration.md
@@ -14,10 +14,10 @@
 For a data provider to offer new data for OpenSAFELY, there are two
 technical requirements:
 
-1. The data being offered must satisfy [OpenSAFELY
-   Contracts](contracts-intro.md).
+1. The data being offered must satisfy [existing OpenSAFELY
+   Contracts](data-provider-integration.md#implementing-existing-opensafely-contracts).
 2. The data backend must have an [implementation in OpenSAFELY Data
-   Builder](data-builder-intro.md).
+   Builder](data-provider-integration.md#data-builder-integration-requirements).
 
 ## Implementing existing OpenSAFELY Contracts
 
@@ -25,7 +25,7 @@ The existing [Contracts reference](contracts-reference.md) provides data
 specifications for both OpenSAFELY users and data providers.
 
 An OpenSAFELY backend implements one or more of these specifications.
-Each specification covers a specific health care data domain.
+Each specification covers a specific healthcare data domain.
 
 For each data column in a Contract, the Contract details:
 
@@ -37,33 +37,41 @@ For each data column in a Contract, the Contract details:
 Refer to those specifications when preparing data tables for integration
 with OpenSAFELY.
 
-### What if provided data does not exactly match the relevant Contract?
+### What if the available Contracts are unsuitable for a data provider?
 
 Structuring data in line with OpenSAFELY Contracts makes it easier for
 researchers using OpenSAFELY to run studies across multiple data
-backends. However, there may be administrative or technical reasons why
-data providers cannot satisfy a Contract precisely.
+backends.
 
-Some deviation from the Contract is permitted.
+However, data providers may have:
 
-TODO: What needs to be done if there is deviation? Is this following
-discussion and approval by OpenSAFELY?
+* data in a considerably different structure from existing Contracts
+* data not covered at all by existing Contracts
 
-TODO: What counts as permitted deviation and what counts as a breach of
-the Contract?
+In these cases, a data provider could propose:
 
-## Proposing new OpenSAFELY Contracts
+* amendments to existing OpenSAFELY Contracts, if appropriate.
+* an entirely new OpenSAFELY Contract. This may involve the creation of
+  a new Contract [namespaced](contracts-intro.md#naming-contracts) to your
+  organisation or backend.
 
 !!! note
+    We see the development of OpenSAFELY Contracts as an ongoing
+    process. Each discussion that we have with data providers informs
+    the design of the Contracts. We aim to continue to iterate and
+    improve on the designs of Contracts, while providing stability
+    through [versioning](contracts-intro.md#versioning).
 
+#### Proposing changes to OpenSAFELY Contracts
+
+!!! note
     OpenSAFELY Contracts are still in an initial design and
     implementation phase. We already have designs for additional
     Contracts that will be implemented in future.
 
-If no existing Contract corresponds to a healthcare data domain that you
-wish to offer, [please email our technical team to
-discuss](mailto:tech@opensafely.org). This may involve the creation of a
-new [Custom Contract](contracts-intro.md#common-and-custom-contracts).
+If no existing Contract corresponds to the healthcare data domain that
+your data covers, [please contact our technical team to discuss how we
+can help](how-to-get-help.md#data-providers).
 
 ## Integrating a data backend into OpenSAFELY Data Builder
 

--- a/docs/how-to-get-help.md
+++ b/docs/how-to-get-help.md
@@ -16,6 +16,10 @@ The most common requests are about library support, and new study definition var
 
 Other than this, you will need to choose the most appropriate repo to submit an issue. If you're not sure where to submit your issue, just ask a question in our [Q&A forum](https://github.com/opensafely/documentation/discussions) and we can point you to the right place.
 
+## Data providers
 
+To discuss making your data available to researchers via the OpenSAFELY
+platform, please [contact our technical
+team](mailto:tech@opensafely.org).
 
 ---8<-- 'includes/glossary.md'

--- a/includes/glossary.md
+++ b/includes/glossary.md
@@ -40,3 +40,4 @@
 *[ehrQL]: electronic health record query language. The language used to extract data for analysis.
 *[OpenSAFELY Contracts]: specifications for the data supplied by different backends; and guidelines and tooling for suppliers wishing to standardise their data.
 *[dataset]: A tabular data structure with one row per patient and one column per variable.
+*[backend]: one of several clinical databases that researchers might query via OpenSAFELY.

--- a/includes/glossary.md
+++ b/includes/glossary.md
@@ -41,3 +41,4 @@
 *[OpenSAFELY Contracts]: specifications for the data supplied by different backends; and guidelines and tooling for suppliers wishing to standardise their data.
 *[dataset]: A tabular data structure with one row per patient and one column per variable.
 *[backend]: one of several clinical databases that researchers might query via OpenSAFELY.
+*[data provider]: an operator of a database (in UK data protection law, a data processor) that contains sensitive patient data; who also provides a secure infrastructure for running OpenSAFELY next to that data.

--- a/includes/glossary.md
+++ b/includes/glossary.md
@@ -40,5 +40,5 @@
 *[ehrQL]: electronic health record query language. The language used to extract data for analysis.
 *[OpenSAFELY Contracts]: specifications for the data supplied by different backends; and guidelines and tooling for suppliers wishing to standardise their data.
 *[dataset]: A tabular data structure with one row per patient and one column per variable.
-*[backend]: one of several clinical databases that researchers might query via OpenSAFELY.
+*[backend]: an individual clinical database that a data provider makes accessible via the OpenSAFELY platform.
 *[data provider]: an operator of a database (in UK data protection law, a data processor) that contains sensitive patient data; who also provides a secure infrastructure for running OpenSAFELY next to that data.


### PR DESCRIPTION
This PR covers an initial pass at explaining OpenSAFELY Contracts.

The actual reference documentation will be included separately; that
documentation will be generated automatically.

It additionally adds the beginnings of a page aimed at backend data
providers. This additional page also discusses Contracts. 