### PR TITLE
Document how to Update Data Builder Docs

### DIFF
--- a/docs/updating-the-docs.md
+++ b/docs/updating-the-docs.md
@@ -29,8 +29,6 @@ the [documentation repository's
 README](https://github.com/opensafely/documentation#building-locally-and-testing)
 that details the use of `pip-compile` for this.
 
----8<-- 'includes/glossary.md'
-
 ## Making changes to the dataset definition examples
 You will need to check out the [documentation repo](https://github.com/opensafely/documentation) so you can run the example generating toolchain.
 
@@ -48,3 +46,28 @@ Examples are included in the markdown files using the [pymdown snippet notation]
 Make sure you commit both the changes to the `examples` and `databuilder/snippets` directories.
 
 If you are updating multiple examples it might be easier to the extraction step happen each time you change the python modules, you can do this with `just databuilder/watch-examples`.
+
+
+## Updating Data Builder backend and contract documentation
+
+!!! note "You will need both Python 3.7 and 3.10 on your PATH to make these updates"
+
+!!! note "This workflow is not supported, and has not been tested on Windows."
+
+Some of the Data Builder information in this OpenSAFELY documentation is generated from the [Data Builder source code](https://github.com/opensafely-core/databuilder).
+
+There are three components used to achieve this:
+
+* [Data Builder repository](https://github.com/opensafely-core/databuilder/)
+* [A mkdocs plugin](https://github.com/opensafely-core/mkdocs-opensafely-databuilder/)
+* [This documentation site](https://github.com/opensafely/documentation/)
+
+To update the [backend](data-backends.md) or [contracts](contracts-reference.md) pages:
+
+1. Make your changes in the [Data Builder repo](https://github.com/opensafely-core/databuilder/).  A new version of databuilder will be released once your changes are merged to `main`.
+1. In the [documentation repo](https://github.com/opensafely/documentation/) run `just databuilder/upgrade-databuilder` to update the version of databuilder installed in the subdirectory's virtualenv.  A current limitation is that a new Data Builder release is needed, before rebuilding the generated content.  Data Builder releases are only made for certain pull requests.
+1. Run `just databuilder/generate-docs` to update the `public_docs.json` file.
+1. Create a branch in the documentation repo and commit the `public_docs.json` file to it.
+1. Submit a PR for your changes.  Cloudflare will build a deployment of your branch if you don't want to test locally.
+
+---8<-- 'includes/glossary.md'


### PR DESCRIPTION
This adds a section on how to update parts of documentation which come from Data Builder.  It assumes the pipeline itself does not need updating, and that we'll document that elsewhere.  My intention was to mirror the old cohortextractor flow of "I have changed something in cohortextractor, how do I update the docs page?"

@StevenMaude – re that elsehwere, do you think that should be another section on this page or live in the relevant projects?