### PR TITLE
Refine ehrQL placeholders

### DIFF
--- a/docs/data-builder-toc.md
+++ b/docs/data-builder-toc.md
@@ -18,6 +18,7 @@
 * [OpenSAFELY Data Builder introduction](data-builder-intro.md)
 * [Writing a dataset definition](dataset-definition.md)
 * [ehrQL: Data Builder's language for querying electronic health record data](ehrql-intro.md)
+* [ehrQL examples](ehrql-examples.md)
 * [ehrQL reference](ehrql-reference.md)
 * [OpenSAFELY Contracts introduction](contracts-intro.md)
 * [OpenSAFELY Contracts reference](contracts-reference.md)

--- a/docs/data-builder-toc.md
+++ b/docs/data-builder-toc.md
@@ -15,11 +15,20 @@
 
 ## Contents
 
+### Data Builder and dataset definitions
+
 * [OpenSAFELY Data Builder introduction](data-builder-intro.md)
 * [Writing a dataset definition](dataset-definition.md)
+
+### ehrQL
+
 * [ehrQL: Data Builder's language for querying electronic health record data](ehrql-intro.md)
+* [ehrQL tutorial](ehrql-tutorial.md)
 * [ehrQL examples](ehrql-examples.md)
 * [ehrQL reference](ehrql-reference.md)
+
+### OpenSAFELY Contracts
+
 * [OpenSAFELY Contracts introduction](contracts-intro.md)
 * [OpenSAFELY Contracts reference](contracts-reference.md)
 * [OpenSAFELY data backends](data-backends.md)

--- a/docs/ehrql-examples.md
+++ b/docs/ehrql-examples.md
@@ -1,0 +1,9 @@
+# ehrQL examples
+
+---8<-- 'includes/data-builder-danger-header.md'
+
+This page will give examples of common uses of [ehrQL](ehrql-intro.md)
+and explain them briefly. This is in addition to the existing [ehrQL
+tutorial](ehrql-tutorial.md).
+
+---8<-- 'includes/glossary.md'

--- a/docs/ehrql-reference.md
+++ b/docs/ehrql-reference.md
@@ -4,6 +4,7 @@
 
 This page will be a reference for the [ehrQL](ehrql-intro.md).
 
-It may be partially or automatically generated.
+It is likely to be derived from the [ehrQL test-based
+specification](https://github.com/opensafely-core/databuilder/tree/main/tests/spec).
 
 ---8<-- 'includes/glossary.md'

--- a/docs/ehrql-tutorial.md
+++ b/docs/ehrql-tutorial.md
@@ -1,0 +1,8 @@
+# ehrQL tutorial
+
+---8<-- 'includes/data-builder-danger-header.md'
+
+This page will contain an [ehrQL](ehrql-intro.md) tutorial. It will
+initially describe how a relatively minimal ehrQL example works.
+
+---8<-- 'includes/glossary.md'


### PR DESCRIPTION
* Add placeholders for simple examples and a tutorial
* Explain how the ehrQL reference page will likely be derived
* Separate out the temporary table of contents using headings 