### PR TITLE
Point to mkdocs in the virtual env

### DIFF
--- a/justfile
+++ b/justfile
@@ -93,7 +93,7 @@ fix: devenv
 
 # Run the dev project
 run: devenv
-    mkdocs serve -a localhost:8910
+    $BIN/mkdocs serve -a localhost:8910
 
 
 link-databuilder:


### PR DESCRIPTION
This fixes `just run`, which previously expected an active virtual environment.