### PR TITLE
Fix toolchains' access to config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,5 +5,5 @@ ignore = \
     W503   # line break before binary operator (black disagrees)
 max-line-length = 88
 per-file-ignores =
-    update-version.py:INP001
-    snippets/*:E402
+    databuilder/update-version.py:INP001
+    databuilder/snippets/*:E402

--- a/databuilder/justfile
+++ b/databuilder/justfile
@@ -95,15 +95,21 @@ test: devenv
 
 # runs the format (black), sort (isort) and lint (flake8) check but does not change any files
 check: devenv
-    $BIN/black --check .
-    $BIN/isort --check-only --diff .
-    $BIN/flake8
+    #!/usr/bin/env bash
+    # config lives in the project root, so run commands there
+    cd {{parent_directory(justfile_directory())}}
+    databuilder/$BIN/black --check databuilder/
+    databuilder/$BIN/isort --check-only --diff databuilder/
+    databuilder/$BIN/flake8 databuilder/
 
 
 # fix formatting and import sort ordering
 fix: devenv
-    $BIN/black .
-    $BIN/isort .
+    #!/usr/bin/env bash
+    # config lives in the project root, so run commands there
+    cd {{parent_directory(justfile_directory())}}
+    databuilder/$BIN/black databuilder/
+    databuilder/$BIN/isort databuilder/
 
 
 # Run the dev project


### PR DESCRIPTION
config is used by three toolchains: Cloudflare Pages (`.venv`), Data
Builder (`databuilder/.venv`), and pre-commit (the tool). To allow each
toolchain to access config, we ensure that flake8's per-file ignores are
relative to the project root, and we run the check and fix recipes in
databuilder/justfile from the project root.

You might be thinking "Cloudflare Pages doesn't need config; so why not
move config to Data Builder?" Well, then we'd break pre-commit (the
tool). You then might be thinking "Why not move pre-commit (the tool) to
Data Builder? Well, then everyone who cloned the repo would have to
setup both Cloudflare Pages and Data Builder to commit, even if the
commit was unrelated to Data Builder (see #619). As well as being
unnecessary, setting up both toolchains is a pain, because
`.python-version`, which is used by Dependabot, prevents pyenv from
putting 3.7 and 3.10 on the PATH.