### PR TITLE
Introduce ehrQL

### DIFF
--- a/docs/ehrql-intro.md
+++ b/docs/ehrql-intro.md
@@ -1,13 +1,26 @@
-# ehrQL: Data Builder's language for querying electronic health record data
+# ehrQL: electronic health record query language
 
 ---8<-- 'includes/data-builder-danger-header.md'
 
-This page will introduce the specialised query language, ehrQL, that
-[Data Builder](data-builder-intro.md) introduces, explaining:
+_ehrQL_, or electronic health record query language, is the language used by Data Builder to extract datasets for analysis.
+It was developed to help researchers write simple, unambiguous queries;
+and to help researchers write queries that weren't anticipated by ehrQL's developers.
 
-* what it is
-* give an overview of its use
-* mention that there is a [more comprehensive
-  reference](ehrql-reference.md)
+The first stage when carrying out research with the OpenSAFELY platform is for the researcher to write a dataset definition in ehrQL.
+A _dataset definition_ specifies the criteria for selecting, and the characteristics of, the population.
+It is used by Data Builder to extract a dataset from an EHR system, where a _dataset_ is a tabular data structure with one row per patient and one column per characteristic.
+
+The following dataset definition, which is written in ehrQL, is from [the tutorial][].
+It specifies a single criterion for selecting the population; namely, that the population should consist of all patients who were born in or after 2000.
+It also specifies a single characteristic of the population; namely, each patient's year of birth.
+
+---8<-- 'examples/src-minimal-ehrql.md'
+
+You can find out more about ehrQL in [the tutorial][] and [the examples][].
+For in-depth technical documentation, there is also [the reference][].
 
 ---8<-- 'includes/glossary.md'
+
+[the examples]: ehrql-examples.md
+[the reference]: ehrql-reference.md
+[the tutorial]: ehrql-tutorial.md

--- a/includes/glossary.md
+++ b/includes/glossary.md
@@ -35,7 +35,7 @@
 *[API]: Application Programming Interface. An agreed way for one system to communicate with another system.
 *[released outputs]: files from Level 4 uploaded to the Jobs site.
 *[draft published outputs]: a collection of released outputs prepared for publication to the general public.
-*[Data Builder]: a program that uses a data definition to create a datasets for analysis
-*[dataset definition]: specifies the details of data — for example, patients — that you want to include in your study. Used by Data Builder.
-*[ehrQL]: electronic health record query language. The language used by the Data Builder tool to extract cohorts
+*[Data Builder]: A program that uses dataset definitions to create datasets for analysis.
+*[dataset definition]: A file that specifies the criteria for selecting, and the characteristics of, the population. Used by Data Builder.
+*[ehrQL]: electronic health record query language. The language used by Data Builder to extract datasets for analysis.
 *[OpenSAFELY Contracts]: provide a specification to make clear the data provided by different data backends, and to provide guidelines and tooling for data providers wishing to standardise their data for researchers


### PR DESCRIPTION
Leads the reader to the tutorial, examples, and reference. Written with reference to [the spec](https://docs.google.com/document/d/1jMEsjH2EbbGzrK-cAwCjSSRkQQ6JZu0YbckmPju2VHc/edit#heading=h.jifperpt4dpf). For more information, see [sc-735](https://app.shortcut.com/ebm-datalab/story/735/add-an-introduction-to-ehrql-to-the-documentation).