### PR TITLE
Update glossary

### DIFF
--- a/includes/glossary.md
+++ b/includes/glossary.md
@@ -38,5 +38,5 @@
 *[Data Builder]: A program that uses dataset definitions to create datasets for analysis.
 *[dataset definition]: A file that specifies the criteria for selecting, and the characteristics of, the population. Used by Data Builder.
 *[ehrQL]: electronic health record query language. The language used by Data Builder to extract datasets for analysis.
-*[OpenSAFELY Contracts]: provide a specification to make clear the data provided by different data backends, and to provide guidelines and tooling for data providers wishing to standardise their data for researchers
+*[OpenSAFELY Contracts]: provide specifications for the data supplied by different backends; and guidelines and tooling for suppliers wishing to standardise their data.
 *[dataset]: A tabular data structure with one row per patient and one column per variable.

--- a/includes/glossary.md
+++ b/includes/glossary.md
@@ -35,8 +35,8 @@
 *[API]: Application Programming Interface. An agreed way for one system to communicate with another system.
 *[released outputs]: files from Level 4 uploaded to the Jobs site.
 *[draft published outputs]: a collection of released outputs prepared for publication to the general public.
-*[Data Builder]: A program that uses dataset definitions to create datasets for analysis.
-*[dataset definition]: A file that specifies the criteria for selecting, and the characteristics of, the population. Used by Data Builder.
-*[ehrQL]: electronic health record query language. The language used by Data Builder to extract datasets for analysis.
-*[OpenSAFELY Contracts]: provide specifications for the data supplied by different backends; and guidelines and tooling for suppliers wishing to standardise their data.
+*[Data Builder]: A program that extracts data for analysis.
+*[dataset definition]: A file that specifies the criteria for selecting, and the characteristics of, the data to extract.
+*[ehrQL]: electronic health record query language. The language used to extract data for analysis.
+*[OpenSAFELY Contracts]: specifications for the data supplied by different backends; and guidelines and tooling for suppliers wishing to standardise their data.
 *[dataset]: A tabular data structure with one row per patient and one column per variable.

--- a/includes/glossary.md
+++ b/includes/glossary.md
@@ -39,3 +39,4 @@
 *[dataset definition]: A file that specifies the criteria for selecting, and the characteristics of, the population. Used by Data Builder.
 *[ehrQL]: electronic health record query language. The language used by Data Builder to extract datasets for analysis.
 *[OpenSAFELY Contracts]: provide a specification to make clear the data provided by different data backends, and to provide guidelines and tooling for data providers wishing to standardise their data for researchers
+*[dataset]: A tabular data structure with one row per patient and one column per variable.


### PR DESCRIPTION
> As the design starts getting finalised, we probably have an idea of what names we are giving to concepts, and what those concepts are.
>
> We should add these definitions to the existing [glossary](https://github.com/opensafely-core/databuilder/blob/main/GLOSSARY.md).
>
> [sc-712](https://app.shortcut.com/ebm-datalab/story/712/update-glossary)

Most of the names and concepts were already in the glossary, so I took the opportunity to respond to some feedback from @evansd on an earlier PR. Some definitions appear in both the glossary and the introduction. I've not copied-and-pasted the text from the former to the latter, instead expanding on the definitions in the latter.