### PR TITLE
Use python-legacy with mkdocstrings

### DIFF
--- a/justfile
+++ b/justfile
@@ -9,6 +9,13 @@ export PIP := BIN + "/python -m pip"
 export COMPILE := BIN + "/pip-compile --allow-unsafe --generate-hashes"
 
 
+# ignore the UserWarning emitted by mkdocstrings about explicitly using its
+# python-legacy extra.  Since this configuration can't be detected by the
+# library we have to ignore the warning.
+# https://github.com/mkdocstrings/mkdocstrings/blob/5867162b2eebf4829d39b6fe74843b60ced05a30/docs/handlers/overview.md#about-the-python-handlers
+export PYTHONWARNINGS := "ignore::UserWarning:mkdocstrings.handlers.python"
+
+
 # list available commands
 default:
     @{{ just_executable() }} --list

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -6,5 +6,5 @@
 mkdocs
 mkdocs-material
 https://github.com/opensafely-core/mkdocs-opensafely-databuilder/archive/ec2251eb17781a8c1958e879dd5f33bd8df6fb07.zip#mkdocs-opensafely-databuilder
-mkdocstrings
+mkdocstrings[python-legacy]
 opensafely-cohort-extractor

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -407,7 +407,7 @@ mkdocs-material-extensions==1.0.3 \
 mkdocs-opensafely-databuilder @ https://github.com/opensafely-core/mkdocs-opensafely-databuilder/archive/ec2251eb17781a8c1958e879dd5f33bd8df6fb07.zip \
     --hash=sha256:9cdcab8c35c8770e63a9bb1e6514a7984506d2b191dba4b37e6e9c322604cd86
     # via -r requirements.prod.in
-mkdocstrings==0.18.1 \
+mkdocstrings[python-legacy]==0.18.1 \
     --hash=sha256:4053929356df8cd69ed32eef71d8f676a472ef72980c9ffd4f933ead1debcdad \
     --hash=sha256:fb7c91ce7e3ab70488d3fa6c073a4f827cdc319042f682ef8ea95459790d64fc
     # via


### PR DESCRIPTION
This adds the `python-legacy` extra to mkdocstrings [as per its docs](https://github.com/mkdocstrings/mkdocstrings/blob/5867162b2eebf4829d39b6fe74843b60ced05a30/docs/handlers/overview.md#about-the-python-handlers) and turns off UserWarnings from that module.