### PR TITLE
Add documentation style section

### DIFF
--- a/docs/updating-the-docs.md
+++ b/docs/updating-the-docs.md
@@ -8,6 +8,12 @@ please do! You can either:
 
 Do not commit changes directly to the main branch.
 
+## Documentation style
+
+When adding or revising text, use [Semantic Line Breaks](https://sembr.org/) rather than fixed length lines.
+With semantic line breaks, the diff is more concise and easier to interpret than with fixed length lines,
+where a single change can propagate through a whole paragraph.
+
 ## Making changes to the study definition variables
 
 Edit the docstrings in the [`patients.py` file in the `cohort-extractor` repository](https://github.com/opensafely-core/cohort-extractor/blob/master/cohortextractor/patients.py).

--- a/docs/updating-the-docs.md
+++ b/docs/updating-the-docs.md
@@ -1,6 +1,6 @@
-OpenSAFELY is a rapidly changing platform and the user documentation should be updated frequently to keep pace. 
-If you are an OpenSAFELY user and want to contribute corrections, clarifications, or new materials to the documentation, 
-please do! You can either:
+OpenSAFELY is a rapidly changing platform and the user documentation should be updated frequently to keep pace.
+If you are an OpenSAFELY user and want to contribute corrections, clarifications, or new materials to the documentation, please do!
+You can either:
 
 * Suggest improvements in an [issue](https://github.com/opensafely/documentation/issues).
 * Clone [the repo](https://github.com/opensafely/documentation) locally, make edits on a new branch, then create a pull request for it.


### PR DESCRIPTION
This documents our preference for semantic line breaks over fixed length
lines when writing documentation, emphasising the migration path
described by the sembr FAQ.

See also ebmdatalab/team-manual#179.