### PR TITLE
Fix databuilder Examples Tooling

### DIFF
--- a/databuilder/justfile
+++ b/databuilder/justfile
@@ -102,6 +102,12 @@ check: devenv
     databuilder/$BIN/isort --check-only --diff databuilder/
     databuilder/$BIN/flake8 databuilder/
 
+    # check Python can execut each example, this catches import errors which
+    # snex doesn't
+    for f in $(find databuilder/snippets -type f); do
+        databuilder/$BIN/python $f
+    done
+
 
 # fix formatting and import sort ordering
 fix: devenv

--- a/databuilder/requirements.prod.in
+++ b/databuilder/requirements.prod.in
@@ -6,4 +6,4 @@ snex
 
 # Dependabot doesn't seem to touch this dependency, likely because it's pinned,
 # so we have a script to update it, run: just databuilder/upgrade-databuilder
-https://github.com/opensafely-core/databuilder/archive/refs/tags/v0.29.0.zip
+https://github.com/opensafely-core/databuilder/archive/refs/tags/v0.32.0.zip

--- a/databuilder/requirements.prod.txt
+++ b/databuilder/requirements.prod.txt
@@ -189,8 +189,8 @@ numpy==1.22.1 \
     --hash=sha256:e60ef82c358ded965fdd3132b5738eade055f48067ac8a5a8ac75acc00cad31f \
     --hash=sha256:f8ad59e6e341f38266f1549c7c2ec70ea0e3d1effb62a44e5c3dba41c55f0187
     # via pandas
-opensafely-databuilder @ https://github.com/opensafely-core/databuilder/archive/refs/tags/v0.29.0.zip \
-    --hash=sha256:eec421f9422abadad053d43f735177309326c42aac58298263f72c1142d6f7da
+opensafely-databuilder @ https://github.com/opensafely-core/databuilder/archive/refs/tags/v0.32.0.zip \
+    --hash=sha256:c00e5f7e42dd66c35c1820bf43e11ce593d4ef34a8c9f34dd4fe3555f4f60bbe
     # via -r requirements.prod.in
 pandas==1.4.0 \
     --hash=sha256:0f19504f2783526fb5b4de675ea69d68974e21c1624f4b92295d057a31d5ec5f \


### PR DESCRIPTION
Sometimes the check tooling doesn't catch that an import is broken.  This explicitly executes the examples to make sure they can access imports.  This also bumps databuilder version to the earliest tag with tables.py since this example was added around the same time as that commit.