### PR TITLE
Add first pass of notes for system integrators

### DIFF
--- a/docs/how-to-get-help.md
+++ b/docs/how-to-get-help.md
@@ -18,6 +18,11 @@ Other than this, you will need to choose the most appropriate repo to submit an 
 
 ## Data providers
 
+We have information on [integration](system-integration.md) elsewhere in this documentation.
+
+For general questions on getting a local integration running,
+please use our [Q&A forum](https://github.com/opensafely/documentation/discussions).
+
 To discuss making your data available to researchers via the OpenSAFELY
 platform, please [contact our technical
 team](mailto:tech@opensafely.org).

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,10 @@ instructions if you wish to install on your own computer.
 
 When you are more comfortable with how OpenSAFELY works, we recommend following one of our OpenSAFELY walkthroughs (see [this notebook](https://github.com/opensafely/os-demo-research#opensafely-demo-materials)) to guide you through the platform workflow on your own computer with dummy data, rather than using the documentation pages alone.
 
+## How can I make my organisation's data available via OpenSAFELY?
+
+See our guidance for [system integrators and data providers](system-integration.md).
+
 !!! note "These documents are a work-in-progress"
     Please see the [Updating the Documentation page](updating-the-docs.md) if you want to make improvements.
 

--- a/docs/system-integration.md
+++ b/docs/system-integration.md
@@ -7,14 +7,14 @@
 
 ## Audience
 
-This page is aimed at:
+This page is aimed at people who want to run their own installation of OpenSAFELY
+as a proof-of-concept trial prior to integrating into the live system.
+
+These people are likely to have one of the following professional roles:
 
 * software developers
 * clinical data providers
 * system integrators
-
-who want to run their own installation of OpenSAFELY
-as a proof-of-concept trial prior to integrating into the live system.
 
 ### Assumed knowledge
 

--- a/docs/system-integration.md
+++ b/docs/system-integration.md
@@ -1,0 +1,82 @@
+!!! warning
+
+    These notes are a work-in-progress.
+    This page provides an overview as guidance only,
+    and not a series of definite instructions.
+    We plan to further expand on this information.
+
+## Audience
+
+This page is aimed at:
+
+* software developers
+* clinical data providers
+* system integrators
+
+who want to run their own installation of OpenSAFELY
+as a proof-of-concept trial prior to integrating into the live system.
+
+### Assumed knowledge
+
+It is taken that you have some familiarity with OpenSAFELY.
+
+If not, you should first refer to:
+
+* [this general overview of OpenSAFELY](https://www.opensafely.org/about/)
+* [the typical researcher workflow](workflow.md)
+* [the introductory tutorial](https://docs.opensafely.org/getting-started/)
+
+## Software components
+
+The [OpenSAFELY technical architecture diagram](technical-architecture.md) shows all of the platform software components
+and how they interact.
+
+The specific steps required to create a minimal setup are:
+
+1. Deploy a [*job runner*](https://github.com/opensafely-core/job-runner) within your secure environment.
+   A minimal configuration simply runs Docker containers
+   and stores any resulting container output on a local disk.
+
+2. Deploy a [*job server*](https://github.com/opensafely-core/job-server)
+   that the *job runner* polls for jobs that end users request to be run.
+
+     It is possible to use our existing [*job server*](https://jobs.opensafely.org);
+     [contact us](how-to-get-help.md#data-providers)
+     if you would like us to configure this for you.
+
+3. Create a secure network with our [*GitHub proxy*](https://github.com/opensafely-core/proxy).
+   This provides access to repositories with research study code to run
+   and Docker images used to run the code.
+
+4. To provide *access to your database* from within your setup,
+   integrate into our [*cohort-extractor*](https://github.com/opensafely-core/cohort-extractor) ETL tool:
+
+     * via an implementation of a backend interface; [this is an example for TPP](https://github.com/opensafely-core/cohort-extractor/blob/main/cohortextractor/tpp_backend.py)
+     * and, if you are using an as-yet unsupported database, a database connector
+
+    !!! warning
+
+        A simpler replacement for cohort-extractor,
+        [DataBuilder](https://github.com/opensafely-core/databuilder),
+        is in development.
+
+        You may prefer to wait for a stable version of DataBuilder
+        before attempting to integrate.
+
+5. *Releasing job outputs* requires:
+
+     * the [*release-hatch*](https://github.com/opensafely-core/release-hatch) tool for reviewing outputs
+     * the [*output-publisher*](https://github.com/opensafely-core/output-publisher) tool for publishing outputs
+
+### Deployment
+
+We use Ubuntu in our deployments.
+Our deployments use [deploy scripts](https://github.com/opensafely-core/backend-server)
+that you can refer to.
+
+## Support
+
+See our [support page](how-to-get-help.md#data-providers-and-system-integrators)
+for details of how to get more assistance on integration.
+
+---8<-- 'includes/glossary.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
               - UK Renal Registry: dataset-ukrr.md
       - Access policies: access-policies.md
       - Technical architecture: technical-architecture.md
+      - Information for system integrators: system-integration.md
   - Getting Started guide: getting-started.md
   - Using OpenSAFELY:
       - Analysis workflow: workflow.md


### PR DESCRIPTION
Partially addresses [this documentation issue](https://github.com/opensafely-core/backend-server/issues/61).

See explanation in 2be926146df649c000c7ea9cdafa657bc05d8509 for more.