### PR TITLE
Use `.md` in internal links to Markdown files

### DIFF
--- a/docs/dataset-definition.md
+++ b/docs/dataset-definition.md
@@ -33,7 +33,7 @@ A simple example of a dataset definition is given below.
 ## `dataset_definition.py` structure
 
 Before writing a dataset definition, add [Data
-Builder](data-builder-intro/#adding-data-builder-to-a-project) to your
+Builder](data-builder-intro.md#adding-data-builder-to-a-project) to your
 OpenSAFELY project.
 
 ### Importing code building blocks

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ To use OpenSAFELY, users must know, or be willing to learn, the following progra
 
 - **Stata, R or Python**
   OpenSAFELY currently supports Stata v16.1, Python 3.8, and R 4.0 for statistical analysis.
-  For security reasons, available libraries are restricted to those provided by the framework. See ["Execution Environments"](actions-pipelines/#execution-environments) for more information.
+  For security reasons, available libraries are restricted to those provided by the framework. See ["Execution Environments"](actions-pipelines.md#execution-environments) for more information.
 - **Git**
 The workflow is strongly integrated into Git/GitHub.
 As a minimum you need to be able to clone a remote git repository, create a branch to work on, commit changes to it, push those changes to the remote repository, create a pull request, and merge branches. We have simple guidance in our [Getting Started guide](getting-started.md) on this if you have never used this tooling before.
@@ -55,7 +55,7 @@ See [git workflow](git-workflow.md) for advice about how to use git effectively.
 **For new users, the best place to begin is the [Getting
 Started](getting-started.md) guide.**
 
-The [Analysis workflow](workflow) gives a high-level view of the steps involved in an OpenSAFELY research project.
+The [Analysis workflow](workflow.md) gives a high-level view of the steps involved in an OpenSAFELY research project.
 
 See our [installation](install-intro.md) pages for complete installation
 instructions if you wish to install on your own computer.

--- a/docs/install-macos.md
+++ b/docs/install-macos.md
@@ -57,7 +57,7 @@ Then enable this version (eg `3.10.1`) in pyenv:
 pyenv global system 3.10.1
 ```
 
-Then install the [OpenSAFELY CLI](../opensafely-cli) with pipx, using the Python installed in the previous step:
+Then install the [OpenSAFELY CLI](opensafely-cli.md) with pipx, using the Python installed in the previous step:
 
 ```bash
 pipx install opensafely --python ~/.pyenv/shims/python3.10
@@ -107,4 +107,4 @@ The Docker service will continue to run in the background and can be accessed fr
 
 You're done!
 
-Now you can navigate to a research repo, on your local machine, and [use `opensafely` via the command line](../opensafely-cli/#using-opensafely-at-the-command-line).
+Now you can navigate to a research repo, on your local machine, and [use `opensafely` via the command line](opensafely-cli.md#using-opensafely-at-the-command-line).


### PR DESCRIPTION
See #642.

Without this, the lychee link checker misinterprets the link.

This also makes the format of internal links consistent with the source
files.