### PR TITLE
Add link checking :link:

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -19,5 +19,6 @@ jobs:
         uses: lycheeverse/lychee-action@v1.4.1
         with:
           args: "--exclude-mail --require-https --verbose --no-progress './**/*.md' './**/*.html'"
+          fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "12 10 * * 2"
 
+permissions:
+  contents: read
+
 jobs:
   links:
     runs-on: ubuntu-latest

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -1,0 +1,23 @@
+---
+name: 'Check links'
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "12 10 * * 2"
+
+jobs:
+  links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v1.4.1
+        with:
+          args: "--exclude-mail --require-https --verbose --no-progress './**/*.md' './**/*.html'"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -3,7 +3,6 @@ name: 'Check links'
 
 # yamllint disable-line rule:truthy
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "12 10 * * 2"

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,9 @@
+https://fonts.gstatic.com
+https://github\.com/opensafely/covid-vaccine-effectiveness-research/*
+https://github\.com/opensafely/rapid-reports/*
+https://github\.com/opensafely/server-instructions/*
+https://github.com/opensafely/documentation/network/updates
+https://github.com/opensafely/research-template/generate
+https://developers\.cloudflare\.com*
+http://www\.encepp\.eu*
+https://www\.tandfonline\.com/doi/pdf/*

--- a/docs/actions-reusable.md
+++ b/docs/actions-reusable.md
@@ -47,7 +47,7 @@ The `config` property, which is optional, describes configuration options.
 
 A reusable action is a public repo within the [`opensafely-actions`](https://github.com/opensafely-actions) organisation.
 It has a `main` branch, which is the release branch;
-versions are marked with [tags](http://git-scm.com/book/en/v2/Git-Basics-Tagging).
+versions are marked with [tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging).
 In the above extract from a study's *project.yaml*, for example, we will run version `v1.0.0` of the reusable action called `a_reusable_action`.
 
 The repo has the following minimal structure:


### PR DESCRIPTION
Fixes #642.

As discussed in #642, checking the links in the documentation source proved useful in finding some broken and outdated links. So, let's try adding this as a regular check. It typically takes around 40-50 seconds in GitHub Actions to run. Most of this is setup time. The link check takes around 10 seconds right now.

This PR:

* Adds [lychee-action](https://github.com/lycheeverse/lychee-action) manually via the Actions tab and on a weekly schedule.
  * We can later review whether to check on every PR.
* Fixes up a non-HTTP URL to HTTPS.
* Excludes some inaccessible URLs from checks; see 1c4198e4e4994b938400c9cd44a91ed322a37511 for reasoning.

If it proves useful and reliable here, we could later consider:

* Applying to other sites with considerable number of links (for example, https://opensafely.org, https://bennett.ox.ac.uk)
* Pulling this workflow out into a composite action or reusable workflow to avoid duplicating the configuration across multiple repositories.