### PR TITLE
Use `--include-verbatim` flag in lychee

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check links
         uses: lycheeverse/lychee-action@v1.5.0
         with:
-          args: "--exclude-mail --require-https --verbose --no-progress './**/*.md' './**/*.html'"
+          args: "--exclude-mail --include-verbatim --require-https --verbose --no-progress './**/*.md' './**/*.html'"
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This continues to check code blocks. It was the previous behaviour, but
changed in lychee.

The v1.5.0 lychee action has an updated lychee, which now supports and
enforces this flag now.

See lycheeverse/lychee-action#116 and lycheeverse/lychee-action#117.