### PR TITLE
IMD Rounding

### DIFF
--- a/docs/dataset-systmone.md
+++ b/docs/dataset-systmone.md
@@ -45,9 +45,19 @@ According to our identifiable data minimisation principles, only representations
 Of ~36 million active patient addresses, less than 55,000 have no MSOA code set. These are a split of no postcode entered, an invalid postcode entered, and no fixed abode.
 
 #### IMD
-IMD (the English Index of Multiple Deprivation) is a ranking of LSOAs based on various characteristics of the region.
-The ranking ranges from 1 to around 33000 (the number of LSOAs in England), where 1 is the most deprived area.  It is rounded to the nearest 100 so that the exact LSOA cannot be derived.
-IMD rankings are redone every 3 or 4 years. For some newly built residences, there is no associated IMD rank, and so IMD is not defined in that case.
+IMD (the English Index of Multiple Deprivation) is a ranking of LSOAs based on various characteristics of the areas.
+The original ranking ranges from 1 to around 33,000 (the number of LSOAs in England),
+where 1 is the most deprived area.
+However, the original ranking is rounded to the nearest 100 in the OpenSAFELY-TPP database,
+so that individual LSOAs cannot be identified.
+Consequently, the rounded ranking ranges from 0 to around 33,000,
+where 0 is the most deprived 49 areas.
+
+IMD rankings are recalculated every 3 or 4 years.
+Consequently, there is no original ranking for some newly built residences.
+In these cases, the rounded ranking is -1.
+
+---8<-- 'includes/imd-warning-header.md'
 
 Occasionally a patient has multiple active registrations on a given date.
 If so, the postcode is chosen as follows: choose the registration with the latest start date; if this is not unique, then choose the registration with the latest end date; if this is not unique, choose at random.

--- a/docs/dataset-systmone.md
+++ b/docs/dataset-systmone.md
@@ -59,8 +59,12 @@ In these cases, the rounded ranking is -1.
 
 ---8<-- 'includes/imd-warning-header.md'
 
-Occasionally a patient has multiple active registrations on a given date.
-If so, the postcode is chosen as follows: choose the registration with the latest start date; if this is not unique, then choose the registration with the latest end date; if this is not unique, choose at random.
+Occasionally, a patient has multiple active registrations on a given date.
+If so, the postcode is chosen as follows:
+
+* choose the registration with the latest start date;
+* if this is not unique, then choose the registration with the latest end date;
+* if this is not unique, then choose the registration at random.
 
 If a patient's postcode is not recorded, then these geographic variables are not available for analysis.
 

--- a/docs/study-def-variables.md
+++ b/docs/study-def-variables.md
@@ -28,6 +28,8 @@ These variables are derived from data held in the patients' primary care records
 ::: cohortextractor.patients.address_as_of
 &nbsp;
 
+---8<-- 'includes/imd-warning-header.md'
+
 ::: cohortextractor.patients.with_gp_consultations
 &nbsp;
 

--- a/includes/imd-warning-header.md
+++ b/includes/imd-warning-header.md
@@ -1,0 +1,4 @@
+!!! warning
+    The original IMD ranking is rounded to the nearest 100 in the OpenSAFELY-TPP database.
+    The rounded IMD ranking ranges from 0 to around 33,000.
+    If there is no original ranking, then the rounded ranking is -1.


### PR DESCRIPTION
Whilst the original ranking ranges from 1 to 33,000ish, the ranking in OpenSAFELY-TPP ranges from 0, because it's rounded to the nearest 100. This means 0 represents the most deprived 49 areas.