### PR TITLE
Use more explicit names for IMD groups

### DIFF
--- a/docs/study-def-tricks.md
+++ b/docs/study-def-tricks.md
@@ -354,23 +354,23 @@ In addition:
   Replacing the extracts makes it harder to construct an audit trail, which reduces computational and analytical transparency;
   [core principles](index.md) of the OpenSAFELY platform.
 
-## Grouping IMD by quintiles
+## Grouping IMD by quintile
 
 ---8<-- 'includes/imd-warning-header.md'
 
-To group IMD by quintiles, then:
+To group IMD by quintile, then:
 
 ```py
 study = StudyDefinition(
     # ...
     imdQ5 = patients.categorised_as(
         {
-            "0": "DEFAULT",
-            "1": "imd >= 0 AND imd < 32800*1/5",
+            "Unknown": "DEFAULT",
+            "1 (most deprived)": "imd >= 0 AND imd < 32800*1/5",
             "2": "imd >= 32800*1/5 AND imd < 32800*2/5",
             "3": "imd >= 32800*2/5 AND imd < 32800*3/5",
             "4": "imd >= 32800*3/5 AND imd < 32800*4/5",
-            "5": "imd >= 32800*4/5 AND imd <= 32800",
+            "5 (least deprived)": "imd >= 32800*4/5 AND imd <= 32800",
         },
         imd = patients.address_as_of(
             "index_date",
@@ -383,5 +383,5 @@ study = StudyDefinition(
 ```
 
 Notice that group 1 contains the LSOAs that have a rounded ranking of greater-than or equal to 0.
-Group 0 contains the LSOAs that are not matched by any other group,
-which includes the LSOAs that have a rounded ranking of -1.
+The "Unknown" group contains the LSOAs that are not matched by any other group,
+which includes the LSOAs that have a ranking of -1 (indicating unknown IMD).


### PR DESCRIPTION
Typically users have coded IMD groups with integers, but there's no reason for the group names not use more descriptive strings. This approach also prevents grouped IMD being used as a purely numeric value downstream. 