### PR TITLE
Ignore `www.icnarc.org` links

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,10 +1,10 @@
 https://fonts.gstatic.com
-https://github\.com/opensafely/covid-vaccine-effectiveness-research/*
-https://github\.com/opensafely/rapid-reports/*
-https://github\.com/opensafely/server-instructions/*
+https?://github\.com/opensafely/covid-vaccine-effectiveness-research(?:/.*)?$
+https?://github\.com/opensafely/rapid-reports(?:/.*)?$
+https?://github\.com/opensafely/server-instructions(?:/.*)?$
 https://github.com/opensafely/documentation/network/updates
 https://github.com/opensafely/research-template/generate
-https://developers\.cloudflare\.com*
-http://www\.encepp\.eu*
-https://www\.tandfonline\.com/doi/pdf/*
+https?://developers\.cloudflare\.com(?:/.*)?$
+https?://www\.encepp\.eu(?:/.*)?$
+https?://www\.tandfonline\.com(?:/.*)?$
 https?://www\.icnarc\.org(?:/.*)?$

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -7,3 +7,4 @@ https://github.com/opensafely/research-template/generate
 https://developers\.cloudflare\.com*
 http://www\.encepp\.eu*
 https://www\.tandfonline\.com/doi/pdf/*
+https?://www\.icnarc\.org(?:/.*)?$


### PR DESCRIPTION
And also refactor and correct the `.lycheeignore` slightly.

This makes it more consistent with the one for `opensafely.org`.

When intending to handle multiple related URLs:

* match the URL
* match any subpath of that URL
* match only the specific subdomain