### PR TITLE
How to search github code

### DIFF
--- a/docs/how-to-get-help.md
+++ b/docs/how-to-get-help.md
@@ -14,7 +14,7 @@ You can search for examples of how specific variables and codelists etc. have be
 
 !!! warning
     Use some caution when looking at code, especially older code:
-    it may have been superseded since.
+    it may never have been run, or may have been superseded since.
 
 To search the OpenSAFELY GitHub organisation for code:
 

--- a/docs/how-to-get-help.md
+++ b/docs/how-to-get-help.md
@@ -8,9 +8,23 @@ If you're outside the onboarding support period, or you're just trying OpenSAFEL
 
 ## Searching past study code
 
-Another useful source of information when writing your analysis is the [OpenSAFELY organisation](https://github.com/opensafely) in GitHub, where all code for previous studies is stored. You can search for examples of how specific variables, codelists etc have been used previously. However, **use with caution**: you may come across old code that has since been superceded/corrected or contains errors. 
+The [GitHub OpenSAFELY organisation](https://github.com/opensafely) is a useful source of information when writing your analysis.
+Our GitHub organisation stores all of the code used for previous studies. 
+You can search for examples of how specific variables and codelists etc. have been used.
 
-On the [organisation page](https://github.com/opensafely), paste search text into the top-left box (`Search or jump to...`) and press return or select the option to search `In this organisation`. Select `Code` to find any matches within previous code (or sometimes `Issues` may help). It can be helpful to use the option to filter the results by Language (e.g. `Python` for study definition files). 
+!!! warning
+    Use some caution when looking at code, especially older code:
+    it may have been superseded since.
+
+To search the OpenSAFELY GitHub organisation for code:
+
+1. Go to the [OpenSAFELY GitHub organisation page](https://github.com/opensafely).
+2. Type or paste your search text into the top-left box (`Search or jump to...`)
+3. Press ++enter++ or select the option to search `In this organisation`.
+4. Select "Code" to find any matches within previous code (or sometimes "Issues" may help).
+
+It can be helpful to use the option to filter the results by language.
+For example, restricting to Python might help you find study definition files. 
 
 ## Bug reports and feature requests
 

--- a/docs/how-to-get-help.md
+++ b/docs/how-to-get-help.md
@@ -1,10 +1,16 @@
 ## Onboarders
 
-When your project has been approved by NHS England, we will agree an intensive support period with you when our statisticians and engineers will be made available to get you started.
+When your project has been approved by NHS England, we will agree an intensive support period with you when our experienced researchers and engineers will be made available to get you started.
 
 ## Q&A Forum
 
 If you're outside the onboarding support period, or you're just trying OpenSAFELY out, your first port of call should be our [Q&A forum](https://github.com/opensafely/documentation/discussions) in GitHub. Before asking for help here, please search the [Q&A forum](https://github.com/opensafely/documentation/discussions) and these documentation pages to check that your query hasn’t already been addressed. Some of the most common issues that users face when using OpenSAFELY are listed in the [FAQ page](https://github.com/opensafely/documentation/discussions/445) on the Q&A.
+
+## Searching past study code
+
+Another useful source of information when writing your analysis is the [OpenSAFELY organisation](https://github.com/opensafely) in GitHub, where all code for previous studies is stored. You can search for examples of how specific variables, codelists etc have been used previously. However, **use with caution**: you may come across old code that has since been superceded/corrected or contains errors. 
+
+On the [organisation page](https://github.com/opensafely), paste search text into the top-left box (`Search or jump to...`) and press return or select the option to search `In this organisation`. Select `Code` to find any matches within previous code (or sometimes `Issues` may help). It can be helpful to use the option to filter the results by Language (e.g. `Python` for study definition files). 
 
 ## Bug reports and feature requests
 


### PR DESCRIPTION
also changed "statisticians" as most OpenSafely copilots would not describe themselves as statisticians (and the assistance provided would normally not involve any strictly statistical issues). 