### PR TITLE
improve page for requesting new libraries

### DIFF
--- a/docs/requesting-libraries.md
+++ b/docs/requesting-libraries.md
@@ -1,31 +1,50 @@
 Additional R, Stata, or Python packages in OpenSAFELY must be added by the OpenSAFELY development team.
 Installing packages via commands that pull the package from the internet (e.g `install.packages()` in R, `ssc install` in Stata or `pip install` in Python) won't work because internet access is restricted in the server.
 
-## Requesting additional packages
+**Before requesting a new package, please first check whether or not the package has already been installed!** See below for how to do this for specific languages. 
 
-If the package you need is not available, you can request it as follows:
+## R packages
 
-* Make a new issue in the appropriate tracker (see below).
-* Explain the rationale
-* Get another member of the support group to chip in on the issue (e.g. do they agree; do they think a different package might do the same thing better)
-* Assign to Simon when discussion finished.
+First check that the package is not already available, by [viewing all installed packages and their versions for the
+OpenSAFELY R image](https://github.com/opensafely-core/r-docker/blob/master/packages.csv). If your package isn't there then [open an
+issue](https://github.com/opensafely-core/r-docker/issues) to request it be added. Include the following information:
 
-### Requesting additional R packages
+* A link to the CRAN page for the package;
+* A brief explanation of why the package is needed;
+* A tag to the @data-team
 
-You can view all installed packages and their versions for the
-[OpenSAFELY R image](https://github.com/opensafely-core/r-docker/blob/master/packages.csv) and [open an
-issue](https://github.com/opensafely-core/r-docker/issues).
+We consider the following things when deciding whether to include a new R package:
 
-### Requesting additional Stata packages
+* Is the package available on [CRAN](https://cran.r-project.org/)? We don't currently support packages that are not on CRAN but feel free to open an issue if you think it warrants further discussion.
+* Is the package "in scope"? In other words does the package help to process and analyse OpenSAFELY-type data, and is this clear from the request? If it's not clear what the package will be used for, we may ask for more information to justify its inclusion, so try to communicate this from the start. Out-of-scope includes:
+    * Packages that are better used outside of the secure OpenSAFELY environment, for example for developing shiny apps, simulating data, or reference management.
+    * Packages that cannot be used inside of the secure OpenSAFELY environment, for example for retrieving online ONS data or interacting with an SQL database.
+    * Irrelevant packages, for example for free-text sentiment analysis or historical shipping forecast data. 
+* Does the package suggest that the user is doing something that may put a lot of strain on the server? For example bootstrapping, multiple imputation, cross-validation, pooled logistic regression, parallelisation, etc. This is usually fine, but we may want to find out more about whether this is an important component of your analysis and if there are alternatives. OpenSAFELY is a shared, finite resource and we have to consider the needs of all users. 
+* It it a really big package? Are there's lots of dependencies that aren't already installed? This is usually fine, but it may be worth considering if there are alternatives.
+* Does the package require other software to be installed on the image? For example the [magick](https://cran.r-project.org/package=magick) package requires Imagemagick to be installed. These will be reported on the CRAN page under `SystemRequirements`. If there are additional system requirements, then the development team will need to take a look and there are no guarantees that it can be installed.
+* Does the package work, or work differently, on Linux than on windows or macOS? The R image is Linux. 
+
+If you need a specific version of a specific package then open [open an
+issue](https://github.com/opensafely-core/r-docker/issues) for discussion.
+
+## Stata packages
 
 You can [open an
-issue](https://github.com/opensafely-core/stata-docker/issues).
+issue](https://github.com/opensafely-core/stata-docker/issues) to request the package is added.
 
-### Requesting additional Python packages
+* A link to information about the package;
+* A brief explanation of why the package is needed;
+* A tag to the @data-team
 
-You can view all installed packages and their versions for the
-[OpenSAFELY Python image](https://github.com/opensafely-core/python-docker/blob/main/requirements.in) and [open an
-issue](https://github.com/opensafely-core/python-docker/issues).
+## Python packages
+
+First check that the package is not already available, by [viewing all installed packages and their versions for the OpenSAFELY Python image](https://github.com/opensafely-core/python-docker/blob/main/requirements.in). If your package isn't there then [open an
+issue](https://github.com/opensafely-core/python-docker/issues) to request it be added. Include the following information:
+
+* A link to information about the package;
+* A brief explanation of why the package is needed;
+* A tag to the @data-team
 
 ## Manual installation
 
@@ -33,7 +52,7 @@ Whilst the long-term solution in most cases should be to install additional pack
 This will only be feasible if the functions do not have a complex hierarchy of dependencies.
 For instance, in many cases, Stata packages can be added by copying the relevant `ado` files into the project repo.
 
-Either way, you should make an Issue for the package so that other users are aware of the package's history in OpenSAFELY.
+Either way, you should make an issue for the package so that other users are aware of the package's history in OpenSAFELY.
 
 
 


### PR DESCRIPTION
The rationale for some repetition across sections is that most people will skip straight to the language that they're interested in, rather than read text at the top.