### PR TITLE
feat: add warning re  limitations of consultations

### DIFF
--- a/docs/study-def-variables.md
+++ b/docs/study-def-variables.md
@@ -33,6 +33,8 @@ These variables are derived from data held in the patients' primary care records
 ::: cohortextractor.patients.with_gp_consultations
 &nbsp;
 
+---8<-- 'includes/gp-consultations-warning-header.md'
+
 ::: cohortextractor.patients.sex
 &nbsp;
 

--- a/includes/gp-consultations-warning-header.md
+++ b/includes/gp-consultations-warning-header.md
@@ -1,4 +1,6 @@
 !!! warning
-    A "consultation" as returned by this function may not neccesarily be a traditional in-person or even remote consultation between a health care professional and patient.
-    Simple administrative tasks such as updating a patient's details may also cause creation of a "consultation" record.
-    As such, careful consideration must be given to usage of variables derived from this function within studies as not to overestimate the frequency of consultations. 
+    A "consultation" as returned by this function may not actually be a consultation between a health care professional and patient.
+
+    For example, simple administrative tasks such as updating a patient's details may also cause creation of a "consultation" record.
+
+    It is, therefore, extremely unlikely you can use this field to infer anything about real clinician-patient interactions, and it is even more difficult to compare activity between practices as recording behaviour can vary. Some EHRs even delete consultation data for a patient when they switch practice.

--- a/includes/gp-consultations-warning-header.md
+++ b/includes/gp-consultations-warning-header.md
@@ -1,0 +1,4 @@
+!!! warning
+    A "consultation" as returned by this function may not neccesarily be a traditional in-person or even remote consultation between a health care professional and patient.
+    Simple administrative tasks such as updating a patient's details may also cause creation of a "consultation" record.
+    As such, careful consideration must be given to usage of variables derived from this function within studies as not to overestimate the frequency of consultations. 


### PR DESCRIPTION
re: https://github.com/opensafely-core/opensafely-cli/issues/120 I've added an extra "health warning" to this function. Whilst the limitations were already present in the documentation, this re-states them more strongly within a formatted warning box