### PR TITLE
Set the number of LSOAs to 32844

### DIFF
--- a/docs/study-def-tricks.md
+++ b/docs/study-def-tricks.md
@@ -366,11 +366,11 @@ study = StudyDefinition(
     imdQ5 = patients.categorised_as(
         {
             "Unknown": "DEFAULT",
-            "1 (most deprived)": "imd >= 0 AND imd < 32800*1/5",
-            "2": "imd >= 32800*1/5 AND imd < 32800*2/5",
-            "3": "imd >= 32800*2/5 AND imd < 32800*3/5",
-            "4": "imd >= 32800*3/5 AND imd < 32800*4/5",
-            "5 (least deprived)": "imd >= 32800*4/5 AND imd <= 32800",
+            "1 (most deprived)": "imd >= 0 AND imd < 32844*1/5",
+            "2": "imd >= 32844*1/5 AND imd < 32844*2/5",
+            "3": "imd >= 32844*2/5 AND imd < 32844*3/5",
+            "4": "imd >= 32844*3/5 AND imd < 32844*4/5",
+            "5 (least deprived)": "imd >= 32844*4/5 AND imd <= 32844",
         },
         imd = patients.address_as_of(
             "index_date",


### PR DESCRIPTION
Although the maximum value in the database is 32800, we should use the maximum value in the "real world", or 32844. For why, see:
https://github.com/opensafely/long-covid/pull/82#discussion_r907409054