### PR TITLE
Document that IMD is similar for EMS

### DIFF
--- a/includes/imd-warning-header.md
+++ b/includes/imd-warning-header.md
@@ -1,4 +1,4 @@
 !!! warning
-    The original IMD ranking is rounded to the nearest 100 in the OpenSAFELY-TPP database.
+    The original IMD ranking is rounded to the nearest 100 in the OpenSAFELY-TPP and OpenSAFELY-EMIS databases.
     The rounded IMD ranking ranges from 0 to 32,800.
-    If there is no original ranking, then the rounded ranking is -1.
+    If there is no original ranking, then the rounded ranking is -1 in the OpenSAFELY-TPP database and `NULL` in the OpenSAFELY-EMIS database.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ plugins:
       custom_templates: templates
       watch:
         - examples
+        - includes
         - public_docs.json
   - mkdocs-opensafely-databuilder
   - macros


### PR DESCRIPTION
Both are rounded, but they represent missing values differently.

I've also added a small QOL enhancement: Mkdocs now watches the _includes_ directory.