### PR TITLE
Updated databuilder docs to remove references to dataset registration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ files: "^databuilder/"
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
     - id: black
 

--- a/databuilder/snippets/ehrql.py
+++ b/databuilder/snippets/ehrql.py
@@ -24,15 +24,8 @@ dataset.year_of_birth = year_of_birth
 dataset.birth_year = year_of_birth
 # :endsnippet
 
-# :snippet minimal-ehrql-register
-from databuilder.definition import register
-
-
-register(dataset)
-# :endsnippet
 
 # :snippet minimal-ehrql
-from databuilder.definition import register
 from databuilder.query_language import Dataset
 from databuilder.tables import patients
 
@@ -41,5 +34,4 @@ year_of_birth = patients.date_of_birth.year
 dataset = Dataset()
 dataset.set_population(year_of_birth >= 2000)
 dataset.year_of_birth = year_of_birth
-register(dataset)
 # :endsnippet

--- a/docs/ehrql-tutorial.md
+++ b/docs/ehrql-tutorial.md
@@ -19,6 +19,9 @@ and set the population, which is all patients who were born in or after 2000:
 
 ---8<-- 'examples/src-minimal-ehrql-set-population.md'
 
+!!! note
+    ehrQL expects a single dataset, named `dataset`.  If we name the dataset something else, an error will be raised.  If we define more than one dataset, only the last one named `dataset` will be registered.
+
 At this point, we have created a dataset and set the population, but we haven't requested any data.
 Let's change that.
 As well as using each patient's year of birth to set the population, we also request it:
@@ -37,10 +40,6 @@ As well as using each patient's year of birth to set the population, we also req
 
     to give the column a different name.
 
-
-Finally, we register the dataset:
-
----8<-- 'examples/src-minimal-ehrql-register.md'
 
 ## Wrapping up
 

--- a/examples/src-minimal-ehrql-register.md
+++ b/examples/src-minimal-ehrql-register.md
@@ -1,6 +1,0 @@
-```python
-from databuilder.definition import register
-
-
-register(dataset)
-```

--- a/examples/src-minimal-ehrql.md
+++ b/examples/src-minimal-ehrql.md
@@ -1,5 +1,4 @@
 ```python
-from databuilder.definition import register
 from databuilder.query_language import Dataset
 from databuilder.tables import patients
 
@@ -8,5 +7,4 @@ year_of_birth = patients.date_of_birth.year
 dataset = Dataset()
 dataset.set_population(year_of_birth >= 2000)
 dataset.year_of_birth = year_of_birth
-register(dataset)
 ```


### PR DESCRIPTION
Fixes #837 

- Removes use of `register()` from snippets and examples
- Adds a note to the ehrql tutorial and naming the dataset
- Also needed to upgrade the version of black in the pre-commit hooks, because of a [problem with click](https://github.com/psf/black/issues/2964)