### PR TITLE
Exclude `../data-sources/` index from link check

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -8,3 +8,20 @@ https?://developers\.cloudflare\.com(?:/.*)?$
 https?://www\.encepp\.eu(?:/.*)?$
 https?://www\.tandfonline\.com(?:/.*)?$
 https?://www\.icnarc\.org(?:/.*)?$
+# The following ignore line ignores this link in the source: ../data-sources
+#
+# MkDocs actually uses an index.md file to generate this,
+# but lychee cannot find it from the link and reports it broken.
+#
+# What lychee tries to resolve in a GitHub Actions runner is:
+# file:///home/runner/work/documentation/documentation/data-sources
+# which doesn't exist.
+#
+# The partial checkout path is included:
+# * because there's no other easy way to try and generalise,
+#   in case someone tries to run this outside of GitHub Actions
+# * to try and avoid any false matches,
+#   in case a similar URL path is used elsewhere in the documentation
+#   (though this is unlikely)
+# This line depends on the repository checkout being in `documentation/`.
+file:///.*/documentation/data-sources/?$

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,9 +1,12 @@
+# Preconnect URL for fonts: 404 when the domain itself is accessed.
 https://fonts.gstatic.com
+# Not accessible without being logged in.
 https?://github\.com/opensafely/covid-vaccine-effectiveness-research(?:/.*)?$
 https?://github\.com/opensafely/rapid-reports(?:/.*)?$
 https?://github\.com/opensafely/server-instructions(?:/.*)?$
 https://github.com/opensafely/documentation/network/updates
 https://github.com/opensafely/research-template/generate
+# Block either the GitHub Actions runner or the lychee client.
 https?://developers\.cloudflare\.com(?:/.*)?$
 https?://www\.encepp\.eu(?:/.*)?$
 https?://www\.tandfonline\.com(?:/.*)?$


### PR DESCRIPTION
This fixes the automated link check by excluding a link that lychee cannot resolve.

See the comment in `.lycheeignore` for why.