### PR TITLE
Workflow to update databuilder docs and open PR

### DIFF
--- a/.github/workflows/update_databuilder_docs.yml
+++ b/.github/workflows/update_databuilder_docs.yml
@@ -1,0 +1,60 @@
+---
+name: 'Update databuilder docs'
+
+on:
+  workflow_dispatch:
+    inputs:
+      download_url: 
+        description: "Download URL for public_docs.json"
+        required: true
+      branch_tag:
+        desription: "Tag to append to the branch name for the new PR"
+        required: true
+
+jobs:
+
+  update_docs:
+    
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3    
+      
+      - name: Download release artifact
+        run: |
+          curl ${{ github.event.inputs.download_url }} > public_docs.json
+
+      - name: commit new docs file
+        env:
+          BRANCH: update-docs-${{ github.event.inputs.branch_tag }}
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git checkout -b $BRANCH
+          git add public_docs.json
+          git commit -m "Update databuilder docs"
+          git push origin $BRANCH
+
+      - name: Open PR
+        uses: actions/github-script@v6
+        env:
+          BRANCH: update-docs-${{ github.event.inputs.branch_tag }}
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const { BRANCH } = process.env;
+            result = await github.rest.pulls.create({
+              title: 'Update databuilder docs',
+              owner,
+              repo,
+              head: BRANCH,
+              base: 'main',
+            });
+            await github.rest.pulls.requestReviewers({
+              owner,
+              repo,
+              pull_number: result.data.number,
+              team_reviewers: ['data-team'],
+            });
+ 


### PR DESCRIPTION
Fixes #768 

Adds a new workflow, which will be triggered by a new workflow in the databuilder repo, which generates a release asset when any the docs change - see https://github.com/opensafely-core/databuilder/pull/630.  The workflow creation is called with the download URL of the new release asset. 

It:
1) downloads the new release asset to `public_docs.json`
2) commits and pushes the updated file to a new branch (tagged with the databuilder sha, sent from the databuilder workflow as `branch_tag`)
3) Creates a PR and requests review from the data-team


The workflow will also be triggerable manually, with a download url for a public_docs.json file, and a unique tag for the branch name