### PR TITLE
Trigger build check after opening automated update docs PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ name: 'build-check'
 # yamllint disable-line rule:truthy
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build-check:

--- a/.github/workflows/update_databuilder_docs.yml
+++ b/.github/workflows/update_databuilder_docs.yml
@@ -55,7 +55,6 @@ jobs:
               owner,
               repo,
               pull_number: result.data.number,
-              team_reviewers: ['data-team'],
             });
       
       - name: Trigger build-check

--- a/.github/workflows/update_databuilder_docs.yml
+++ b/.github/workflows/update_databuilder_docs.yml
@@ -57,4 +57,19 @@ jobs:
               pull_number: result.data.number,
               team_reviewers: ['data-team'],
             });
+      
+      - name: Trigger build-check
+        uses: actions/github-script@v6
+        env:
+          BRANCH: update-docs-${{ github.event.inputs.branch_tag }}
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const { BRANCH } = process.env;
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'opensafely',
+              repo: 'documentation',
+              workflow_id: 'build.yml',
+              ref: BRANCH,
+            })
  


### PR DESCRIPTION
The build-check  workflow is triggerd by PRs, but apparently not by the one opened by the update-databuilder-docs workflow.  I think this is because it's using the GITHUB_TOKEN, which is by default.  So now we manually trigger at the end of the update-databuilder-docs workflow.

I also removed the `team_reviewers: ['data-team']` from the PR step of the update-databuilder-docs workflow; the data-team is in a different organisation so can't be added as a reviewer here. 