### PR TITLE
Update databuilder install docs and just commands

### DIFF
--- a/.github/workflows/update_databuilder_docs.yml
+++ b/.github/workflows/update_databuilder_docs.yml
@@ -51,11 +51,6 @@ jobs:
               head: BRANCH,
               base: 'main',
             });
-            await github.rest.pulls.requestReviewers({
-              owner,
-              repo,
-              pull_number: result.data.number,
-            });
       
       - name: Trigger build-check
         uses: actions/github-script@v6

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,11 +24,11 @@ reference to them in
 
 ### Updating Data Builder Definitions
 
-Data Builder is a documentation dependency which we can't install directly.
-Cloudflare Pages' latest Python version is 3.7, but Data Builder is using 3.9 features.
-Rather than limit Data Builder to the versions supported by Cloudflare Pages, we've opted to have it generate a JSON file from Data Builder and commit that JSON to this repo.
+Data Builder generates some documentation automatically in JSON format from backend and contract code, and from its spec tests.  When a new Data Builder version builds and generates updates to
+the documentation, a PR to update the JSON file in this repo is automatically opened.
 
-Run `just databuilder/generate-docs` to generate the JSON file using `databuilder` installed in the `databuilder` subdirectory of this repo.
+The current and past versions of the Data Builder JSON file can be found as release artifacts
+with [Data Builder releases](https://github.com/opensafely-core/databuilder/releases).
 
 If the JSON file has changed you might need to update [the plugin which uses it to render pages](https://github.com/opensafely-core/mkdocs-opensafely-backend-contracts/).
 

--- a/databuilder/justfile
+++ b/databuilder/justfile
@@ -102,7 +102,7 @@ check: devenv
     databuilder/$BIN/isort --check-only --diff databuilder/
     databuilder/$BIN/flake8 databuilder/
 
-    # check Python can execut each example, this catches import errors which
+    # check Python can execute each example, this catches import errors which
     # snex doesn't
     for f in $(find databuilder/snippets -type f); do
         databuilder/$BIN/python $f
@@ -133,7 +133,3 @@ watch-examples:
     #!/usr/bin/env bash
     project_root=$(git rev-parse --show-toplevel)
     $BIN/watchmedo shell-command --patterns="*.py" --recursive --command="just ${project_root}/databuilder/extract" "${project_root}/databuilder/snippets"
-
-
-generate-docs:
-    $BIN/python -m databuilder.docs >../public_docs.json

--- a/justfile
+++ b/justfile
@@ -103,6 +103,3 @@ fix: devenv
 run: devenv
     $BIN/mkdocs serve -a localhost:8910
 
-
-link-databuilder:
-    ln -sf ../databuilder/backend_docs.json .


### PR DESCRIPTION
Fixes #863 

Remove just commands to link databuilder and generate docs now that the databuilder JSON is updated automatically.

Also fix a step in the update docs workflow.