### PR TITLE
Remove warning from with_gp_consultations docs

### DIFF
--- a/docs/study-def-variables.md
+++ b/docs/study-def-variables.md
@@ -33,8 +33,6 @@ These variables are derived from data held in the patients' primary care records
 ::: cohortextractor.patients.with_gp_consultations
 &nbsp;
 
----8<-- 'includes/gp-consultations-warning-header.md'
-
 ::: cohortextractor.patients.sex
 &nbsp;
 

--- a/includes/gp-consultations-warning-header.md
+++ b/includes/gp-consultations-warning-header.md
@@ -1,6 +1,0 @@
-!!! warning
-    A "consultation" as returned by this function may not actually be a consultation between a health care professional and patient.
-
-    For example, simple administrative tasks such as updating a patient's details may also cause creation of a "consultation" record.
-
-    It is, therefore, extremely unlikely you can use this field to infer anything about real clinician-patient interactions, and it is even more difficult to compare activity between practices as recording behaviour can vary. Some EHRs even delete consultation data for a patient when they switch practice.


### PR DESCRIPTION
This warning is now included in the docstring

Addresses part of opensafely-core/opensafely-cli#120