### PR TITLE
Use correct `gitsubmodule` name for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
   schedule:
     interval: "monthly"
 
-- package-ecosystem: "submodules"
+- package-ecosystem: "gitsubmodule"
   directory: "/"
   schedule:
     interval: "daily"


### PR DESCRIPTION
No idea where `submodules` came from(?)