### PR TITLE
Wrangle black version for consistency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,8 @@ default_language_version:
 
 repos:
   - repo: https://github.com/psf/black
+    # Pinned temporarily for consistency with the databuilder directory's
+    # requirements; see #886.
     rev: 21.12b0
     hooks:
     - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     rev: 21.12b0
     hooks:
     - id: black
+      additional_dependencies: ['click<8']
 
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1

--- a/databuilder/requirements.dev.in
+++ b/databuilder/requirements.dev.in
@@ -6,6 +6,7 @@
 
 # Pin black for now to avoid dependency constraint conflict.
 # black and snex both use click, but snex uses an older version of click.
+# See #886.
 black==21.12b0
 flake8
 flake8-builtins


### PR DESCRIPTION
This was broken.

pre-commit would try to install Black 21.12b0, but with click 8 and this didn't work.

See #885 and commit message 6bf6a7bdbbdd805b624b2cf83deb5f7d78efbdcf for more on why we're in this situation.