### PR TITLE
Use `--unsafe` YAML check for `mkdocs.yml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,10 @@ repos:
     - id: check-json
     - id: check-toml
     - id: check-yaml
+      exclude: mkdocs.yml
+    - id: check-yaml
+      name: check-yaml-mkdocs
+      # --unsafe is a workaround for the use of !! in mkdocs.yml.
+      args: [--unsafe]
+      files: mkdocs.yml
     - id: detect-private-key


### PR DESCRIPTION
See https://github.com/pre-commit/pre-commit-hooks/issues/273

The check currently fails because we use the `!!` syntax in the current
`mkdocs.yml` configuration.

`--unsafe` refers to the YAML compliance: it doesn't load the file, merely
checks the syntax:

> Instead of loading the files, simply parse them for syntax.
> A syntax-only check enables extensions and unsafe constructs which would otherwise be forbidden.
> Using this option removes all guarantees of portability to other yaml implementations.

https://github.com/pre-commit/pre-commit-hooks/blob/98c88b23b7ea9a42f920adc1d7c8790f39772021/README.md#check-yaml

This is still better than the current situation because:

* a complete failure requires a committer to use `--no-verify`
  or spend time trying to work out what's wrong with the pre-commit
  failure
* there is still a rudimentary check of this YAML, which doesn't happen
  in the current broken state

In practice, this YAML file gets loaded by MkDocs, which tells us if it's broken
anyway.

Other YAML files in this repository are still checked fully.