### PR TITLE
Skip publish step for Dependabot

### DIFF
--- a/.github/workflows/pages-deployment.yml
+++ b/.github/workflows/pages-deployment.yml
@@ -31,6 +31,7 @@ jobs:
         run: echo ${{ github.sha }} > site/version.html
 
       - name: Publish
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: cloudflare/pages-action@1
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Dependabot does not have access to secrets, so that malicious
dependencies cannot exfiltrate those secrets.

Because of this, the publish step fails for Dependabot PRs as the
Cloudflare secrets are not available.

We could consider a more sophisticated separation of build and publish
in future.