### PR TITLE
Remove reference to databuilder release assets

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,7 +45,4 @@ by hand: `just update-cohort-extractor`
 Data Builder generates some documentation automatically in JSON format from backend and contract code, and from its spec tests. When a new Data Builder version builds and generates updates to
 the documentation, a PR to update the JSON file in this repo is automatically opened. The PR is opened by a [workflow in the Data Builder repository](https://github.com/opensafely-core/databuilder/blob/main/.github/workflows/update-public-docs.yml).
 
-The current and past versions of the Data Builder JSON file can be found as release artifacts
-with [Data Builder releases](https://github.com/opensafely-core/databuilder/releases).
-
 If the JSON file has changed you might need to update [the plugin which uses it to render pages](https://github.com/opensafely-core/mkdocs-opensafely-backend-contracts/).


### PR DESCRIPTION
Databuilder no longer creates releases for documentation updates, so remove reference to it here too.