### PR TITLE
Add `project.yaml` explainer for Data Builder

### DIFF
--- a/databuilder/ehrql-tutorial-examples/project.yaml
+++ b/databuilder/ehrql-tutorial-examples/project.yaml
@@ -1,0 +1,11 @@
+version: "3.0"
+
+expectations:
+  population_size: 3000
+
+actions:
+  extract_minimal_cohort:
+    run: databuilder:v0 generate-dataset "./1a_minimal_dataset_definition.py" --dsn "example-data/minimal"
+    outputs:
+      highly_sensitive:
+        cohort: outputs/1a_minimal_dataset_definition.csv

--- a/docs/ehrql-new-tutorial-intro.md
+++ b/docs/ehrql-new-tutorial-intro.md
@@ -19,6 +19,7 @@
 * [Dataset definition 1a](ehrql-new-tutorial-1a.md)
 * [Dataset definition 1b](ehrql-new-tutorial-1b.md)
 * [Dataset definition 2a](ehrql-new-tutorial-2a.md)
+* [Using ehrQL and Data Builder in an OpenSAFELY project](ehrql-new-tutorial-opensafely-project.md)
 * [Unwritten remaining section placeholders](ehrql-new-tutorial-remaining-sections.md)
 
 ## Audience

--- a/docs/ehrql-new-tutorial-opensafely-project.md
+++ b/docs/ehrql-new-tutorial-opensafely-project.md
@@ -1,0 +1,102 @@
+# Using Data Builder in an OpenSAFELY project
+
+---8<-- 'includes/data-builder-danger-header.md'
+
+!!! todo
+
+    We should consider moving all the examples to be project based
+    and covering some of the topics here earlier on.
+
+## The relationship between Data Builder and OpenSAFELY projects
+
+### Learning objectives
+
+By the end of this tutorial, you should know how to:
+
+* Create an OpenSAFELY project that uses Data Builder.
+* Run that project to generate the dataset definition output.
+
+### Running Data Builder via an OpenSAFELY project
+
+So far in this tutorial,
+we have run dataset definitions entirely via Data Builder.
+
+This is fine for learning purposes in this tutorial.
+However, to run against an OpenSAFELY backend,
+we must create an OpenSAFELY project.
+
+To create an OpenSAFELY project,
+there are three steps:
+
+1. Create the dataset definition,
+   as we have already covered in these tutorial examples.
+2. Create an OpenSAFELY project that uses Data Builder,
+   by writing a `project.yaml` file.
+3. Use the OpenSAFELY CLI to run that `project.yaml` file.
+
+### Requirements
+
+In addition to the previous requirements,
+you will also need the [OpenSAFELY CLI](opensafely-cli.md) installed.
+
+### The dataset definition we will work with
+
+We will use a simple dataset definition that we have already seen.
+
+```python title="1a_minimal_dataset_definition.py"
+---8<-- "databuilder/ehrql-tutorial-examples/1a_minimal_dataset_definition.py"
+```
+
+### The `minimal` data source
+
+`minimal/1a_minimal_dataset_definition.csv`
+
+{{ read_csv('databuilder/ehrql-tutorial-examples/example-data/minimal/patient_demographics.csv') }}
+
+### The `project.yaml`
+
+!!! todo
+
+    Make this work, and check that it works.
+    It requires the OpenSAFELY CLI to be able to run the `project.yaml` correctly.
+    It also requires the correct options adding to this YAML file.
+
+A `project.yaml` file configures how analytic code is run for OpenSAFELY projects.
+
+Using Data Builder in a `project.yaml` is much like working with other OpenSAFELY used by other OpenSAFELY actions.
+
+```yaml title="project.yaml"
+---8<-- "databuilder/ehrql-tutorial-examples/project.yaml"
+```
+
+### Running the `project.yaml`
+
+!!! todo
+
+    Add any extra details that are required.
+    It may be that the `DATABASE_URL` or similar must be specified by environment variable.
+
+Running a `project.yaml` which contains a Data Builder action
+is much the same as for any other OpenSAFELY project.
+
+Use [`opensafely run`](opensafely-cli.md/#run) to run the `project.yaml`:
+
+1. In your terminal, change directory to where you have the example `project.yaml` file.
+2. Run `opensafely run run_all`
+3. The OpenSAFELY CLI should run Data Builder with the dataset definition
+   and you should find the output in the relative path shown under `outputs` in the `project.yaml`.
+
+### Tutorial exercises
+
+!!! todo
+
+    What is required to create a new OpenSAFELY project?
+    Do you need a Git repository configured?
+
+!!! question
+
+    1. Can you create an OpenSAFELY project
+       for one of the other dataset definitions we have covered in these tutorials?
+    2. Try running that project
+       and confirm that the outputs are the same
+       as running the dataset definition directly with Data Builder.


### PR DESCRIPTION
This is not completely finished. However, to do so, requires getting the
`project.yaml` working, which may not be possible yet.

In future, we may prefer to integrate this information earlier, and
replace the existing examples that run with Data Builder directly, with
entire OpenSAFELY projects: one for each dataset definition.

For now, this at least makes the connection between Data Builder and
OpenSAFELY `project.yaml` explicit.