### PR TITLE
Remove pipx

### DIFF
--- a/docs/install-macos.md
+++ b/docs/install-macos.md
@@ -6,6 +6,7 @@
 Open Terminal.app by clicking the magnifying glass icon in the top right of your screen.
 Type `terminal` and hit ++enter++.
 
+## Homebrew
 Install [Homebrew](https://brew.sh/), this should install the Xcode Command Line Tools for you as well.
 
 !!! note "This command might take a while to run depending on the speed of your internet connection."
@@ -26,6 +27,7 @@ Next, install [Docker for Mac](https://docs.docker.com/docker-for-mac/install/),
 brew install --cask docker github visual-studio-code
 ```
 
+## pyenv
 Configure your shell to use pyenv:
 
 !!! note
@@ -39,6 +41,7 @@ echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.
 echo 'eval "$(pyenv init -)"' >> ~/.zshrc
 ```
 
+## Python
 Use pyenv to install Python:
 
 !!! note "This command might take a while to run depending on the speed of your computer."
@@ -56,6 +59,7 @@ Then enable this version (eg `3.10.1`) in pyenv:
 pyenv global system 3.10.1
 ```
 
+## OpenSAFELY CLI
 Then install the [OpenSAFELY CLI](opensafely-cli.md) with pip:
 
 ```bash
@@ -82,6 +86,7 @@ available commands:
               Commands for interacting with https://www.opencodelists.org/
 ```
 
+## Docker for Mac
 Set up Docker by opening the app you installed earlier:
 
 ```bash

--- a/docs/install-macos.md
+++ b/docs/install-macos.md
@@ -14,30 +14,29 @@ Install [Homebrew](https://brew.sh/), this should install the Xcode Command Line
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
-Once homebrew is installed use it to install [pipx](https://pipxproject.github.io/pipx/) and [pyenv](https://github.com/pyenv/pyenv):
+Once homebrew is installed use it to install [pyenv](https://github.com/pyenv/pyenv):
 
 ```bash
-brew install pipx pyenv
+brew install pyenv
 ```
-
-Add pipx to your path with:
-
-```bash
-echo 'export PATH="$HOME/.local/bin/:$PATH"' >> ~/.zshrc
-```
-
-and reload your shell environment with:
-
-```bash
-source ~/.zshrc
-```
-
-!!! note "If you are using a shell other than ZSH you will need to edit and source the appropriate config file"
 
 Next, install [Docker for Mac](https://docs.docker.com/docker-for-mac/install/), [GitHub Desktop](https://desktop.github.com/), and [Visual Studio Code](https://code.visualstudio.com/):
 
 ```bash
 brew install --cask docker github visual-studio-code
+```
+
+Configure your shell to use pyenv:
+
+!!! note
+    If you are using a shell other than ZSH you will need to edit and source
+    the appropriate config file.  pyenv has documentation for getting set up
+    on [various shells](https://github.com/pyenv/pyenv#set-up-your-shell-environment-for-pyenv).
+
+```bash
+echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
+echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
+echo 'eval "$(pyenv init -)"' >> ~/.zshrc
 ```
 
 Use pyenv to install Python:
@@ -57,10 +56,10 @@ Then enable this version (eg `3.10.1`) in pyenv:
 pyenv global system 3.10.1
 ```
 
-Then install the [OpenSAFELY CLI](opensafely-cli.md) with pipx, using the Python installed in the previous step:
+Then install the [OpenSAFELY CLI](opensafely-cli.md) with pip:
 
 ```bash
-pipx install opensafely --python ~/.pyenv/shims/python3.10
+pip install opensafely
 ```
 
 Test the installation of OpenSAFELY CLI.


### PR DESCRIPTION
This removes pipx from the macOS installation docs since opensafely-cli has no dependencies and the primary use of pipx is to provide a place to install python tools with dependencies without using your global python env.

This does add a possible risk for future maintenance in that we're now telling users to configure pyenv such it should take priority over a homebrewed or system python.  While this is considered the correct way to install Python on macOS (because homebrew and system pythons can be updated out from under you), my concern is that it ends up with further burden on our tech support.  The pipx method used the pyenv-installed python but didn't put it on ones path.  This is _probably_ fine, but if we see any issues with it I think it makes sense to switch back to the pipx method. 

Fixes: #1026