### PR TITLE
Specify `site_url` in MkDocs configuration for correct sitemap

### DIFF
--- a/.github/workflows/pages-deployment.yml
+++ b/.github/workflows/pages-deployment.yml
@@ -25,7 +25,7 @@ jobs:
           python3 -m pip install -r ./requirements.txt
 
       - name: Build site
-        run: mkdocs build
+        run: MKDOCS_SITE_URL="https://docs.opensafely.org" mkdocs build
 
       - name: Add a version file
         run: echo ${{ github.sha }} > site/version.html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: OpenSAFELY documentation
+site_url: !ENV MKDOCS_SITE_URL
 repo_url: https://github.com/opensafely/documentation
 nav:
   - Introduction: index.md


### PR DESCRIPTION
Fixes #1053.

To correctly generate the `sitemap.xml`, the [`site_url` must be specified in `mkdocs.yml`](https://github.com/mkdocs/mkdocs/issues/1783).

Having a valid sitemap can help search engines [index a site's content](https://developers.google.com/search/docs/crawling-indexing/sitemaps/overview).

What I've done here is to make `site_url` switchable depending on an environment variable, `MKDOCS_SITE_URL` and then simply set that on build. As this is only really required for deployment, I've just put this in the deployment workflow, instead of adding some wrapper or to do the build with the environment variable supplied.

This keeps the local development setup exactly as it was, with no value set for `site_url`.

I'm reasonably convinced that this is the right approach because:

* we can override the `site_url`
  * to set as an empty string if we ever want to build a [local file distribution](https://www.mkdocs.org/user-guide/deploying-your-docs/#local-files) (this may not be necessary with a missing value, but not tested)
  * when running locally with no URL set, the configuration is as it was previously (although I think with `mkdocs serve`, the site URL is ignored anyway!)
* we probably do want the canonical URL to be `https://docs.opensafely.org/some-path…` even for Cloudflare test deployments, technically, should a search engine somehow stumble upon those pages