### PR TITLE
Revert "Add warning about VMP IDs"

### DIFF
--- a/docs/study-def-variables.md
+++ b/docs/study-def-variables.md
@@ -57,8 +57,6 @@ These variables are derived from data held in the patients' primary care records
 ::: cohortextractor.patients.with_these_medications
 &nbsp;
 
----8<-- 'includes/vmp-ids-warning.md'
-
 ::: cohortextractor.patients.with_these_clinical_events
 &nbsp;
 

--- a/includes/vmp-ids-warning.md
+++ b/includes/vmp-ids-warning.md
@@ -1,7 +1,0 @@
-!!! warning
-    dm+d codes for Virtual Medicinal Products (VMPs) can change.
-    cohort-extractor handles this by automatically expanding a medication codelist
-    to include all current and previous codes of any VMPs in the codelist.
-    However, this means that when a VMP code has changed, a query using
-    `patients.with_these_medications(codelist, returning="code", ...)`
-    might return a code that is not in the provided codelist.


### PR DESCRIPTION
Reverts opensafely/documentation#1059 — accidentally merged ahead of time