### PR TITLE
Remove unneeded documentation following the Data Builder docs migration

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@ This should install everything required.
 ### Data Builder
 
 The Data Builder documentation is imported from the
-[data-builder](https://github.com/opensafely-core/data-builder) repo using the
+[databuilder](https://github.com/opensafely-core/databuilder) repo using the
 [mkdocs-multirepo-plugin](https://github.com/jdoiro3/mkdocs-multirepo-plugin) and built alongside the docs in this repo.  By default it uses the main branch.  This can
 be configured with the `DATABUILDER_BRANCH` environment variable:
 

--- a/docs/updating-the-docs.md
+++ b/docs/updating-the-docs.md
@@ -35,39 +35,5 @@ the [documentation repository's
 README](https://github.com/opensafely/documentation#building-locally-and-testing)
 that details the use of `pip-compile` for this.
 
-## Making changes to the dataset definition snippets
-
-These snippets are separate from the tutorial examples in `databuilder/ehrql-tutorial-examples`.
-There is a separate README in that directory that explains how those tutorial examples work.
-We may eventually unify the tutorial examples with the snippet
-so that all example code is checked in the same way.
-
-Edit the python modules in the `databuilder/snippets` directory.
-
-Examples are included in the markdown files using the [pymdown snippet notation](https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#snippets-notation).
-
-Each of the snippets sections in each snippet Python source file are bounded by markers:
-
-```python
-# --8<-- [start:print]
-print("hello world")
-# --8<-- [end:print]
-```
-
-If this example was stored as `databuilder/snippets/hello.py`,
-then it could be included in the documentation Markdown source via:
-
-````
-```python
-;--8<-- 'databuilder/snippets/hello.py:print'
-```
-````
-
-## Updating Data Builder backend, contract and reference documentation
-
-If a new Data Builder version is released that updates Data Builder's backend, contract and reference documentation,
-there should be an automated pull request opened in the documentation repository to keep it synchronised.
-
-See the [documentation repository's installation notes](https://github.com/opensafely/documentation/blob/main/INSTALL.md).
 
 ---8<-- 'includes/glossary.md'


### PR DESCRIPTION
This PR removes notes that have been moved to Data Builder in opensafely-core/databuilder#963.