### PR TITLE
Adding preprint recommendation for copilots

### DIFF
--- a/docs/copiloting-service.md
+++ b/docs/copiloting-service.md
@@ -114,7 +114,7 @@ All OpenSAFELY outputs require approval from NHS England before they can be diss
 
 ## What is our authorship policy?
 
-We encourage all our users to preprint their work on [medRxiv](https://www.medrxiv.org/), [bioRxiv](https://www.biorxiv.org/) or any other preprint server, though this isn't a requirement as we understand there may be a good reason not to preprint.
+We encourage all our users who produce traditional academic papers to preprint their work. The vast majority of OpenSAFELY papers have been preprinted on on [medRxiv](https://www.medrxiv.org/), however we are happy for them to be preprinted on other servers. If you are using other servers please let us know why so we can try them out if appropriate.
 
 Authorship should be discussed at the introductory meeting of any copiloted project. Our specific policy regarding authorship for copiloted projects is outlined below:
 

--- a/docs/copiloting-service.md
+++ b/docs/copiloting-service.md
@@ -114,7 +114,7 @@ All OpenSAFELY outputs require approval from NHS England before they can be diss
 
 ## What is our authorship policy?
 
-We encourage all our users who produce traditional academic papers to preprint their work. The vast majority of OpenSAFELY papers have been preprinted on on [medRxiv](https://www.medrxiv.org/), however we are happy for them to be preprinted on other servers. If you are using other servers please let us know why so we can try them out if appropriate.
+We encourage all our users who produce traditional academic papers to preprint their work. The vast majority of OpenSAFELY papers have been preprinted on on [medRxiv](https://www.medrxiv.org/), however we are happy for them to be preprinted on other servers. If you typically use other preprint servers, please let us know so that we can assess whether they are appropriate for OpenSAFELY studies.
 
 Authorship should be discussed at the introductory meeting of any copiloted project. Our specific policy regarding authorship for copiloted projects is outlined below:
 

--- a/docs/copiloting-service.md
+++ b/docs/copiloting-service.md
@@ -114,6 +114,8 @@ All OpenSAFELY outputs require approval from NHS England before they can be diss
 
 ## What is our authorship policy?
 
+We encourage all our users to preprint their work on [medRxiv](https://www.medrxiv.org/), [bioRxiv](https://www.biorxiv.org/) or any other preprint server, though this isn't a requirement as we understand there may be a good reason not to preprint.
+
 Authorship should be discussed at the introductory meeting of any copiloted project. Our specific policy regarding authorship for copiloted projects is outlined below:
 
 - The OpenSAFELY copilot(s) for the project should always be offered authorship. Sometimes, if the copilot has needed to do a substantial amount of work to deliver a data analysis project for or with a collaborator organisation, it may be appropriate for the copilot to be offered joint first authorship (but not first). Appropriateness of joint first-authorship should be discussed with your co-pilot based on the extent of their contribution to your project.

--- a/docs/copiloting-service.md
+++ b/docs/copiloting-service.md
@@ -7,7 +7,8 @@ All new users of the OpenSAFELY platform are offered access to our copilot servi
 The service includes five days (over four weeks) of dedicated 1:1 support with cohort extraction via the OpenSAFELY plaform and advise with regards to Github.
 
 Beyond this initial four week period, we also provide:
-- community support via GitHub forums and the #opensafely-users Slack channel
+
+- community support via GitHub forums and the `#opensafely-users` Slack channel
 - output checking service
 - manuscript review
 - opportunities to present at quarterly OpenSAFELY User Group meetings


### PR DESCRIPTION
Adding a line about recommending preprinting to the copiloting documentation, as requested [here](https://bennettoxford.slack.com/archives/C028EJH752A/p1676028540785359).