### PR TITLE
Changing the spelling of 'copilot' to 'co-pilot'

### DIFF
--- a/docs/copiloting-service.md
+++ b/docs/copiloting-service.md
@@ -1,8 +1,8 @@
-# OpenSAFELY copiloting service
+# OpenSAFELY co-piloting service
 
-## What is the OpenSAFELY copiloting service?
+## What is the OpenSAFELY co-piloting service?
 
-All new users of the OpenSAFELY platform are offered access to our copilot service, which pairs the new user (the "pilot") with an experienced OpenSAFELY researcher (the "copilot") to help with the onboarding process. The objective of this service is to help new users get up and running with OpenSAFELY as quickly as possible and aims to facilitate the generation of analytical outputs from real data within a four week period.
+All new users of the OpenSAFELY platform are offered access to our co-pilot service, which pairs the new user (the "pilot") with an experienced OpenSAFELY researcher (the "co-pilot") to help with the onboarding process. The objective of this service is to help new users get up and running with OpenSAFELY as quickly as possible and aims to facilitate the generation of analytical outputs from real data within a four week period.
 
 The service includes five days (over four weeks) of dedicated 1:1 support with cohort extraction via the OpenSAFELY plaform and advise with regards to Github.
 
@@ -13,7 +13,7 @@ Beyond this initial four week period, we also provide:
 - manuscript review
 - opportunities to present at quarterly OpenSAFELY User Group meetings
 
-## What are the aims of the OpenSAFELY copiloting service?
+## What are the aims of the OpenSAFELY co-piloting service?
 
 By the end of the 4 week period, pilots should:
 
@@ -23,9 +23,9 @@ By the end of the 4 week period, pilots should:
 * Run analysis scripts on the population
 * Generated outputs ready for review
 
-## How does the copiloting service run?
+## How does the co-piloting service run?
 
-The diagram below illustrates how a project will progress through the copiloting service. More information about each stage is provided in subsections below.
+The diagram below illustrates how a project will progress through the co-piloting service. More information about each stage is provided in subsections below.
 
 ```mermaid
 flowchart TD
@@ -36,7 +36,7 @@ flowchart TD
         getting_started[Completing Getting Started guide]
     end
     subgraph assignment_stage[" "]
-            copilot_assignment[Assignment of copilot]
+            copilot_assignment[Assignment of co-pilot]
             introductory_meeting[Introductory meeting]
             copilot_assignment --> introductory_meeting
     end
@@ -73,23 +73,23 @@ flowchart TD
 
 ### Project application and software setup
 
-All projects need to have sought and been granted [IG approval](https://www.opensafely.org/policies-for-researchers/) before a copilot can be requested and assigned. We also ask that new users complete the OpenSAFEELY [Getting Started guide](https://docs.opensafely.org/en/latest/getting-started/) to ensure that the necessary software can be installed and run on your computer.
+All projects need to have sought and been granted [IG approval](https://www.opensafely.org/policies-for-researchers/) before a co-pilot can be requested and assigned. We also ask that new users complete the OpenSAFEELY [Getting Started guide](https://docs.opensafely.org/en/latest/getting-started/) to ensure that the necessary software can be installed and run on your computer.
 
-In our experience, copiloting is most successful when the pilot has some experience with coding (e.g., Python, R or Stata), is familiar with collaborative code development via GitHub and is able to commit four weeks or more to their project. However, we have had people with the required motivation and enthusiasm, and an existing adjacent skillset, to get results within four weeks.
+In our experience, co-piloting is most successful when the pilot has some experience with coding (e.g., Python, R or Stata), is familiar with collaborative code development via GitHub and is able to commit four weeks or more to their project. However, we have had people with the required motivation and enthusiasm, and an existing adjacent skillset, to get results within four weeks.
 
-If you are unsure whether copiloting will work for your project, contact `team@opensafely.org` or use the [contact form on our website](https://www.opensafely.org/contact/).
+If you are unsure whether co-piloting will work for your project, contact `team@opensafely.org` or use the [contact form on our website](https://www.opensafely.org/contact/).
 
-### Assignment of copilot
+### Assignment of co-pilot
 
-Once a project has been approved, it will be matched to one of our internal OpenSAFELY researchers, in terms of the experience and knowledge required for the project. The pilot and copilot will have an introductory meeting in which the copilot will provide further details about the copiloting service and the pilot can provide further details about the research project. At this meeting, both parties will agree when the dedicated 1:1 support period will begin.
+Once a project has been approved, it will be matched to one of our internal OpenSAFELY researchers, in terms of the experience and knowledge required for the project. The pilot and co-pilot will have an introductory meeting in which the co-pilot will provide further details about the co-piloting service and the pilot can provide further details about the research project. At this meeting, both parties will agree when the dedicated 1:1 support period will begin.
 
-The slides that we use for these meetings are available [here](https://docs.google.com/presentation/d/16wAFjIPRLef3UbibSRO1R7E2GXmRohPT/edit?usp=share_link). Some of our copilots also run through a version of these slides in [this video on our Youtube channel](https://youtu.be/3BNmoV7aHwA).
+The slides that we use for these meetings are available [here](https://docs.google.com/presentation/d/16wAFjIPRLef3UbibSRO1R7E2GXmRohPT/edit?usp=share_link). Some of our co-pilots also run through a version of these slides in [this video on our Youtube channel](https://youtu.be/3BNmoV7aHwA).
 
-### Active copiloting stage (four weeks)
+### Active co-piloting stage (four weeks)
 
-The four week period of copiloting is intended to provide a supportive, encouraging environment in which a new user can become familiar with how to build and run a research study using the OpenSAFELY platform. In our experience, pilots get the most out of the service if they are able to focus exclusively on the project for the four week period.
+The four week period of co-piloting is intended to provide a supportive, encouraging environment in which a new user can become familiar with how to build and run a research study using the OpenSAFELY platform. In our experience, pilots get the most out of the service if they are able to focus exclusively on the project for the four week period.
 
-Copilots will provide up to five days over the four weeks to support the development of the research study. This support includes:
+co-pilots will provide up to five days over the four weeks to support the development of the research study. This support includes:
 
 - explaining and demonstrating how OpenSAFELY works
 - weekly meetings to scope out achievable weekly objectives and tackle problems
@@ -104,11 +104,11 @@ Copilots will provide up to five days over the four weeks to support the develop
 - coaching, advice and feedback with regards to best practice on GitHub
 - communicating with the OpenSAFELY tech team on the pilot's behalf with regards to platform development
 
-Please note that copilots will not perform code review of any analysis scripts or review any codelists that are developed. This is because this expertise lies with the pilot and their wider research team; pilots will be advised to identify someone within their own organisation who is willing to review this component of the project.
+Please note that co-pilots will not perform code review of any analysis scripts or review any codelists that are developed. This is because this expertise lies with the pilot and their wider research team; pilots will be advised to identify someone within their own organisation who is willing to review this component of the project.
 
-## What happens after the copiloting period is over (the 'post copiloting stage')?
+## What happens after the co-piloting period is over (the 'post co-piloting stage')?
 
-It is not expected that the research project will be complete at the end of the active copiloting period, rather that the pilot will have acquired the relevant experience to complete the project independently. All community resources (the [discussion forum](https://github.com/opensafely/documentation/discussions) and the `#opensafely-users` Slack channel) will remain accessible to the pilots but regular, dedicated 1:1 support for study implementation will end. The copilot will remain involved in the project over the long term in terms of output checking and manuscript review.
+It is not expected that the research project will be complete at the end of the active co-piloting period, rather that the pilot will have acquired the relevant experience to complete the project independently. All community resources (the [discussion forum](https://github.com/opensafely/documentation/discussions) and the `#opensafely-users` Slack channel) will remain accessible to the pilots but regular, dedicated 1:1 support for study implementation will end. The co-pilot will remain involved in the project over the long term in terms of output checking and manuscript review.
 
 All OpenSAFELY outputs require approval from NHS England before they can be disseminated any wider than the pilot's research group. This includes academic manuscripts (pre-printed or peer-reviewed), conference abstracts and presentations, internal reports and masters/PhD theses. Our IG team will handle the NHS England approval process; for more information about how to request NHS England approval and what to include in your publication text please see [this section of our documentation](https://www.opensafely.org/policies-for-researchers/).
 
@@ -116,9 +116,9 @@ All OpenSAFELY outputs require approval from NHS England before they can be diss
 
 We encourage all our users who produce traditional academic papers to preprint their work. The vast majority of OpenSAFELY papers have been preprinted on on [medRxiv](https://www.medrxiv.org/), however we are happy for them to be preprinted on other servers. If you typically use other preprint servers, please let us know so that we can assess whether they are appropriate for OpenSAFELY studies.
 
-Authorship should be discussed at the introductory meeting of any copiloted project. Our specific policy regarding authorship for copiloted projects is outlined below:
+Authorship should be discussed at the introductory meeting of any co-piloted project. Our specific policy regarding authorship for co-piloted projects is outlined below:
 
-- The OpenSAFELY copilot(s) for the project should always be offered authorship. Sometimes, if the copilot has needed to do a substantial amount of work to deliver a data analysis project for or with a collaborator organisation, it may be appropriate for the copilot to be offered joint first authorship (but not first). Appropriateness of joint first-authorship should be discussed with your co-pilot based on the extent of their contribution to your project.
+- The OpenSAFELY co-pilot(s) for the project should always be offered authorship. Sometimes, if the co-pilot has needed to do a substantial amount of work to deliver a data analysis project for or with a collaborator organisation, it may be appropriate for the co-pilot to be offered joint first authorship (but not first). Appropriateness of joint first-authorship should be discussed with your co-pilot based on the extent of their contribution to your project.
 - A core team of people who contribute to the running of the OpenSAFELY platform which facilitate every study that is completed should also be offered authorship. This includes people who contribute to the platform, code, data acquisition, data curation and management, and design of OpenSAFELY.
 - In some circumstances (for example multiple consortia outputs across a diverse range of different datasets in a diverse range of different platforms with an extremely large number of contributors) it might be appropriate for some OpenSAFELY team to be authors, and others making smaller specific contributions to that single output to be listed under the group author name “The OpenSAFELY Collaborative” if the journal permits this in a manner that ensures that the individual names of members of that group author name also appear in Google Scholar and PubMed records (as is common with many journals).
 - As with standard authorship guidelines, named authors must be given the opportunity to read and approve the final manuscript before submission. Persons offered authorship should also have the opportunity to decline the offer if preferred.

--- a/docs/copiloting-service.md
+++ b/docs/copiloting-service.md
@@ -36,20 +36,20 @@ flowchart TD
         getting_started[Completing Getting Started guide]
     end
     subgraph assignment_stage[" "]
-            copilot_assignment[Assignment of co-pilot]
+            co-pilot_assignment[Assignment of co-pilot]
             introductory_meeting[Introductory meeting]
-            copilot_assignment --> introductory_meeting
+            co-pilot_assignment --> introductory_meeting
     end
-    subgraph copiloting_stage[" "]
+    subgraph co-piloting_stage[" "]
         subgraph dedicated_support[1:1 support]
-            active_copiloting[Weekly meetings\nCohort review]
+            active_co-piloting[Weekly meetings\nCohort review]
         end
         subgraph wider_support[Community support]
             wider_support_details[Discussion forum\nUsers Slack channel]
         end
         output_checking[Output checking]
     end
-    subgraph post_copiloting_stage[" "]
+    subgraph post_co-piloting_stage[" "]
         subgraph wider_support_post[Community support]
             wider_support_details_post[Discussion forum\nUsers Slack channel]
         end
@@ -58,17 +58,17 @@ flowchart TD
     end
     getting_started --> assignment_stage
     application_approval --> assignment_stage
-    introductory_meeting --> copiloting_stage
-    copiloting_stage --> post_copiloting_stage
+    introductory_meeting --> co-piloting_stage
+    co-piloting_stage --> post_co-piloting_stage
     style setup_stage fill:#f7fcb9,stroke:#aaa
     style assignment_stage fill:#addd8e,stroke:#333
-    style copiloting_stage fill:#31a354,stroke:#333
+    style co-piloting_stage fill:#31a354,stroke:#333
     style dedicated_support color:white
-    style active_copiloting color:white
+    style active_co-piloting color:white
     style wider_support color:white
     style wider_support_details color:white
     style output_checking color:white
-    style post_copiloting_stage fill:#fff,stroke:#333
+    style post_co-piloting_stage fill:#fff,stroke:#333
 ```
 
 ### Project application and software setup

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,7 @@ nav:
   - Data Builder: '!import https://github.com/opensafely-core/databuilder?branch=main'
   - Support:
       - How to get help: how-to-get-help.md
-      - OpenSAFELY copiloting service: copiloting-service.md
+      - OpenSAFELY co-piloting service: copiloting-service.md
       - Requesting new libraries: requesting-libraries.md
       - Requesting study definition variables: requesting-variables.md
       - Plan S and OpenSAFELY: plan-s.md


### PR DESCRIPTION
I had been lazy (or maybe efficient?) and had used "copilot" rather than "co-pilot" throughout the co-piloting documentation. This is corrected in this commit.

Two exceptions:
1. the name of the file (`copiloting_service.md`) has not been changed however just in case this breaks links that have been shared outside of this documentation
2. "copilot" is used in mermaid diagram labels, as "-" may not be an acceptable character