### PR TITLE
Rename Cloudflare API token secret

### DIFF
--- a/.github/workflows/pages-deployment.yml
+++ b/.github/workflows/pages-deployment.yml
@@ -41,7 +41,7 @@ jobs:
         uses: cloudflare/pages-action@c2ad89679f0dee1ff4bcf9b8bbe1cf52d176cb29  # v1.3.0
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          apiToken: ${{ secrets.CLOUDFLARE_DIRECT_UPLOAD_API_TOKEN }}
           directory: "site"
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           projectName: "opensafely-docs"


### PR DESCRIPTION
To both prevent name collisions, and make it more obvious what the token is for.