### PR TITLE
Enable "edit page" button

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ theme:
     scheme: opensafely
   custom_dir: overrides
   features:
+    - content.action.edit
     - content.code.copy
     - navigation.footer
     - navigation.indexes


### PR DESCRIPTION
This got disabled on the upgrade to Material for MkDocs v9.