### PR TITLE
Adding guidance for adding a paper to OpenSAFELY.org

### DIFF
--- a/docs/adding-a-paper.md
+++ b/docs/adding-a-paper.md
@@ -1,4 +1,4 @@
-
+# Adding an OpenSAFELY paper to OpenSAFELY.org
 
 We are very keen to compile all pre-printed and published OpenSAFELY studies on [opensafely.org](www.opensafely.org).
 

--- a/docs/adding-a-paper.md
+++ b/docs/adding-a-paper.md
@@ -1,0 +1,36 @@
+We are very keen to compile all pre-printed and published OpenSAFELY studies on [opensafely.org](www.opensafely.org).
+
+To do this, open a new file in a text editor of your choice. Populate the file using the following template:
+
+```
+---
+title: "Short title for the page"
+date: yyyy-mm-dd
+status: "preprint" or "published"
+paper: "Title of the paper"
+description: "Description of the paper"
+cite: "How to cite this paper"
+link: "https://doi.org/..."
+---
+
+## Abstract
+
+### Background 
+
+### Methods
+
+### Results
+
+### Conclusions
+
+```
+
+First, update the frontmatter (i.e., the text between the `---`s) with the correct details for your paper. Note that `status:` should have the value `preprint` or `published` to indicate the current status of your manuscript. Then, add the necessary text below the `## Abstract` line to include the abstract.
+
+This file format is called "Markdown", for more help writing Markdown documents, see:
+
+- [Markdown Guide: Basic Syntax](https://www.markdownguide.org/basic-syntax/)
+- [Markdown Guide: Cheat Sheet](https://www.markdownguide.org/cheat-sheet/)
+- [Dillinger: this shows a preview of your Markdown as you type](https://dillinger.io/)
+
+This file can then be incorporated into our website by anyone with the required access; if you are an external researcher, then you can send this to your co-pilot who will have the necessary permissions.

--- a/docs/adding-a-paper.md
+++ b/docs/adding-a-paper.md
@@ -1,3 +1,5 @@
+
+
 We are very keen to compile all pre-printed and published OpenSAFELY studies on [opensafely.org](www.opensafely.org).
 
 To do this, open a new file in a text editor of your choice. Populate the file using the following template:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,7 +68,7 @@ nav:
         - Create a draft: reports/create-a-draft.md
         - Review process: reports/review-process.md
         - Publishing a report: reports/publish-a-report.md
-      - Adding your pre-print or paper: adding-a-paper.md
+      - Adding your pre-print/paper: adding-a-paper.md
   - OpenSAFELY best practice:
       - Bennett Institute Open Manifesto: open-data-manifesto.md
       - Publishing your GitHub Repository: publishing-repo.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,7 +68,7 @@ nav:
         - Create a draft: reports/create-a-draft.md
         - Review process: reports/review-process.md
         - Publishing a report: reports/publish-a-report.md
-      - Adding your pre-print/paper: adding-a-paper.md
+      - Adding your pre-print/paper to OpenSAFELY.org: adding-a-paper.md
   - OpenSAFELY best practice:
       - Bennett Institute Open Manifesto: open-data-manifesto.md
       - Publishing your GitHub Repository: publishing-repo.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
         - Create a draft: reports/create-a-draft.md
         - Review process: reports/review-process.md
         - Publishing a report: reports/publish-a-report.md
+      - Adding your pre-print or paper: adding-a-paper.md
   - OpenSAFELY best practice:
       - Bennett Institute Open Manifesto: open-data-manifesto.md
       - Publishing your GitHub Repository: publishing-repo.md


### PR DESCRIPTION
Internal users will have access to this information via the Team Manual. We have included the information here so that external users can prepare a `.md` file that their co-pilot can then incorporate into the website.