### PR TITLE
Add workflow_dispatch trigger for pages-deployment

### DIFF
--- a/.github/workflows/pages-deployment.yml
+++ b/.github/workflows/pages-deployment.yml
@@ -1,4 +1,7 @@
-on: [push]
+---
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
This is needed to allow databuilder to trigger a new build and deploy of the docs site.