### PR TITLE
Ignore twitter links in .lycheeignore

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -12,6 +12,11 @@ https?://www\.encepp\.eu(?:/.*)?$
 https?://www\.tandfonline\.com(?:/.*)?$
 https?://www\.icnarc\.org(?:/.*)?$
 https?://doi\.org(?:/.*)?$
+
+# Twitter used to work but is being very flaky.
+# This exclusion should be reviewed in future to see if the issue persists.
+https?://twitter\.com(?:/.*$)?$
+
 # The following ignore line ignores this link in the source: ../data-sources
 #
 # MkDocs actually uses an index.md file to generate this,


### PR DESCRIPTION
Databuilder docs links checks are failing because twitter links are timing out
https://github.com/opensafely-core/databuilder/actions/runs/4356281164/jobs/7614146161#step:5:172

In fact it seems it's nitter.net that's timing out due to this [behaviour in lychee](https://github.com/lycheeverse/lychee/blob/684668f78085642b8dac8c427cd601b2e6b6cbbc/lychee-lib/src/quirks/mod.rs#L26)

See also: https://github.com/lycheeverse/lychee-action/issues/178#issuecomment-1374829092

Whatever; let's just ignore it.