### PR TITLE
Update glossary

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,12 @@ default_language_version:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
     - id: black
 
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
     - id: flake8
       additional_dependencies:
@@ -17,12 +17,12 @@ repos:
       - "flake8-no-pep420"
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
     - id: isort
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
     - id: trailing-whitespace
     - id: end-of-file-fixer

--- a/includes/glossary.md
+++ b/includes/glossary.md
@@ -34,10 +34,9 @@
 *[API]: Application Programming Interface. An agreed way for one system to communicate with another system.
 *[released outputs]: files from Level 4 uploaded to the Jobs site.
 *[draft published outputs]: a collection of released outputs prepared for publication to the general public.
-*[Data Builder]: A program that extracts data for analysis.
-*[dataset definition]: A file that specifies the criteria for selecting, and the characteristics of, the data to extract.
-*[ehrQL]: electronic health record query language. The language used to extract data for analysis.
-*[OpenSAFELY Contracts]: specifications for the data supplied by different backends; and guidelines and tooling for suppliers wishing to standardise their data.
+*[Data Builder]: A program that extracts EHR data for analysis.
+*[dataset definition]: Describes, using ehrQL, the EHR data to extract from a backend.
+*[ehrQL]: The Electronic Health Records Query Language. A Domain-Specific Language (DSL) for EHR data.
 *[dataset]: A tabular data structure with one row per patient and one column per variable.
 *[backend]: an individual clinical database that a data provider makes accessible via the OpenSAFELY platform.
 *[data provider]: an operator of a database (in UK data protection law, a data processor) that contains sensitive patient data; who also provides a secure infrastructure for running OpenSAFELY next to that data.


### PR DESCRIPTION
The glossary now better reflects the glossary in the Data Builder repo. It's not an exact copy-and-paste, because this glossary is for a user and that glossary is for a developer.