### PR TITLE
Updating link to copiloting slides

### DIFF
--- a/docs/copiloting-service.md
+++ b/docs/copiloting-service.md
@@ -83,7 +83,7 @@ If you are unsure whether co-piloting will work for your project, contact `team@
 
 Once a project has been approved, it will be matched to one of our internal OpenSAFELY researchers, in terms of the experience and knowledge required for the project. The pilot and co-pilot will have an introductory meeting in which the co-pilot will provide further details about the co-piloting service and the pilot can provide further details about the research project. At this meeting, both parties will agree when the dedicated 1:1 support period will begin.
 
-The slides that we use for these meetings are available [here](https://docs.google.com/presentation/d/16wAFjIPRLef3UbibSRO1R7E2GXmRohPT/edit?usp=share_link). Some of our co-pilots also run through a version of these slides in [this video on our Youtube channel](https://youtu.be/3BNmoV7aHwA).
+The slides that we use for these meetings are available [here](https://docs.google.com/presentation/d/1tOajKhvCy9zWfmAyFHsFXhml3onp7DaJ/edit?usp=share_link&ouid=116818038849804976910&rtpof=true&sd=true). Some of our co-pilots also run through a version of these slides in [this video on our Youtube channel](https://youtu.be/3BNmoV7aHwA).
 
 ### Active co-piloting stage (four weeks)
 


### PR DESCRIPTION
A warning has been added to the co-piloting introductory slides to ensure that pilots are aware of restrictions on sharing data from the server. This commit updates the link on the co-piloting page so that it points to the new version of these slides.