### PR TITLE
Build site to pull in databuilder repo before checking links

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check links
         uses: lycheeverse/lychee-action@9ace499fe66cee282a29eaa628fdac2c72fa087f  # v1.6.1
         with:
-          args: "--exclude-all-private --exclude-mail --include-verbatim --require-https --verbose --no-progress --timeout 60 './**/*.md' './**/*.html'"
+          args: "--exclude-all-private --exclude-mail --include-verbatim --require-https --verbose --no-progress --timeout 60 './docs/**/*.md' './docs/**/*.html', './imported_docs/**/*.md' './imported_docs/**/*.html'"
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -5,17 +5,34 @@ name: 'Check links'
 on:
   workflow_dispatch:
   schedule:
-    - cron: '12 10 * * 2'
+    - cron: '12 10 * * *'
 
 permissions:
   contents: read
 
 jobs:
+
   links:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Install Python and just
+        uses: opensafely-core/setup-action@v1
+        with:
+          install-just: true
+          python-version: '3.11'
+
+      - name: Build site
+        env:
+          AccessToken: ${{ secrets.GITHUB_TOKEN }}
+          MKDOCS_SITE_URL: https://docs.opensafely.org
+          MKDOCS_MULTIREPO_CLEANUP: true
+          DATABUILDER_BRANCH: main
+        run: just build
 
       - name: Check links
         uses: lycheeverse/lychee-action@9ace499fe66cee282a29eaa628fdac2c72fa087f  # v1.6.1
@@ -24,3 +41,13 @@ jobs:
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: "Notify Slack on Failure"
+        if: failure()
+        uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # v1.6.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel_id: C03FB777L1M
+          status: "Check Docs Links Failure"
+          color: danger


### PR DESCRIPTION
Upgrading this repo to 3.11 broke the link checking in the ehrql repo. Since that link-checking actually did the checking on a checkout of this repo, it makes sense to just put the ehrql link checking here too.

- build site first so the link checker also checks ehrql links
- increase frequency of workflow run to nightly (ehrql changes regularly, we want to check links more frequently than once a week)
- Add the notify slack job for failures
