### PR TITLE
Disable the scheduled link check

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -4,8 +4,6 @@ name: 'Check links'
 # yamllint disable-line rule:truthy
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '12 10 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
We intend to run this periodically manually, prompted on Slack.

See opensafely-core/ehrql#1244.