### PR TITLE
Replace placeholder on "Registered deaths" page

### DIFF
--- a/docs/data-sources/onsdeaths.md
+++ b/docs/data-sources/onsdeaths.md
@@ -6,7 +6,7 @@ Date and cause of death based on information recorded when deaths are certified 
 * **Participation / Coverage** Deaths occurring in England and Wales, including non-residents.
 * **Provenance** General Register Office.
 * **Update frequency in OpenSAFELY** Approximately weeekly.
-* **Available from** deaths recorded from X onwards.
+* **Available from** deaths recorded from February 2019 onwards.
 * **Delay between event occurring and event appearing in OpenSAFELY** Approximately 1-2 weeks.
 * **Collected information** Date of death, causes of death, age, sex, place of death.
 


### PR DESCRIPTION
I checked that data are available from February 2019 onwards on L2.

Closes #1219