### PR TITLE
Check URLs in imported ehrQL content

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -36,10 +36,13 @@ jobs:
       - name: Move imported documentation to correct relative path
         run: mv imported_docs/* docs/
 
+      # Use --max-concurrency to prevent 429 errors with OpenSAFELY Jobs.
+      # This workaround may not be needed in future if lychee has better rate limiting.
+      # https://github.com/lycheeverse/lychee/issues/36
       - name: Check links
         uses: lycheeverse/lychee-action@ec3ed119d4f44ad2673a7232460dc7dff59d2421  # v1.8.0
         with:
-          args: "--exclude-all-private --exclude-mail --include-verbatim --require-https --verbose --no-progress --timeout 60 './docs/**/*.md' './docs/**/*.html', './imported_docs/**/*.md' './imported_docs/**/*.html' --exclude-path './docs/ehrql/includes/generated_docs'"
+          args: "--exclude-all-private --exclude-mail --include-verbatim --max-concurrency 24 --require-https --verbose --no-progress --timeout 60 './docs/**/*.md' './docs/**/*.html' './imported_docs/**/*.md' './imported_docs/**/*.html' --exclude-path './docs/ehrql/includes/generated_docs'"
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check links
         uses: lycheeverse/lychee-action@ec3ed119d4f44ad2673a7232460dc7dff59d2421  # v1.8.0
         with:
-          args: "--exclude-all-private --exclude-mail --include-verbatim --require-https --verbose --no-progress --timeout 60 './docs/**/*.md' './docs/**/*.html', './imported_docs/**/*.md' './imported_docs/**/*.html'"
+          args: "--exclude-all-private --exclude-mail --include-verbatim --require-https --verbose --no-progress --timeout 60 './docs/**/*.md' './docs/**/*.html', './imported_docs/**/*.md' './imported_docs/**/*.html' --exclude-path './docs/ehrql/includes/generated_docs'"
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -33,6 +33,9 @@ jobs:
           EHRQL_BRANCH: main
         run: just build
 
+      - name: Move imported documentation to correct relative path
+        run: mv imported_docs/* docs/
+
       - name: Check links
         uses: lycheeverse/lychee-action@ec3ed119d4f44ad2673a7232460dc7dff59d2421  # v1.8.0
         with:

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -30,7 +30,6 @@ jobs:
         env:
           AccessToken: ${{ secrets.GITHUB_TOKEN }}
           MKDOCS_SITE_URL: https://docs.opensafely.org
-          MKDOCS_MULTIREPO_CLEANUP: true
           EHRQL_BRANCH: main
         run: just build
 


### PR DESCRIPTION
Fixes #1252.
Fixes #1281.

This PR allows

* most of the links in the ehrQL docs content to be checked
* the links to that ehrQL docs content from the surrounding documentation content in this repository to be checked

It *does not* check the links in the Markdown files in the `docs/generated_docs` directory from the `ehrql` repository to be checked. These contain relative links, but those relative links cannot be correctly resolved from the directory from which they reside in the repository. See commit message for 791e1786dd0b6c44b8ac23077a319a586c3388a8; I have opened #1288 for this.