### PR TITLE
Add basic Vale configuration

### DIFF
--- a/.github/workflows/check_docs.yml
+++ b/.github/workflows/check_docs.yml
@@ -1,0 +1,32 @@
+---
+name: 'Check docs'
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  summarise-docs-warnings:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Install just
+        uses: opensafely-core/setup-action@v1
+        with:
+          install-just: true
+
+      - name: Install Vale
+        run: |
+          curl -L $(curl "https://api.github.com/repos/errata-ai/vale/releases/latest" | jq -r '.assets[].browser_download_url | select(contains("Linux_64-bit"))') > /tmp/vale.tar.gz
+          mkdir -p "$HOME/.local/bin"
+          tar -xvzf "/tmp/vale.tar.gz" -C "$HOME/.local/bin"
+
+      - name: Run Vale on docs
+        run: NO_COLOR=1 just lint-docs >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/check_vale.yml
+++ b/.github/workflows/check_vale.yml
@@ -1,5 +1,5 @@
 ---
-name: 'Check docs'
+name: 'Check docs with Vale'
 
 # yamllint disable-line rule:truthy
 on:
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  summarise-docs-warnings:
+  summarise-vale-docs-warnings:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.vale.ini
+++ b/.vale.ini
@@ -2,5 +2,5 @@ StylesPath = styles
 
 MinAlertLevel = suggestion
 
-[*]
+[*.md]
 BasedOnStyles = OpenSAFELY

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,6 @@
+StylesPath = styles
+
+MinAlertLevel = suggestion
+
+[*]
+BasedOnStyles = OpenSAFELY

--- a/README.md
+++ b/README.md
@@ -4,12 +4,39 @@ This is the public documentation for using the [OpenSAFELY platform](https://www
 
 It provides information on how to get set up with and use the platform.
 
-## Link checking
+## Automated checks
+
+We have some automated checks that help us maintain the documentation.
+
+These are not enforced for new contributions,
+but can be run by GitHub Actions.
+
+### Content style checks
+
+We have a small number of style rules written for the [Vale style checker](https://github.com/errata-ai/vale).
+
+The purpose of these checks is to help keep our documentation more consistent,
+even when multiple authors are working on it.
+
+If these style checks prove useful,
+we could expand on these into a more fully featured style guide.
+
+The rules are stored in the [`styles` directory](styles/).
+The rules are written in YAML.
+See [Vale's documentation](https://vale.sh/docs/) for more information on Vale rules.
+
+These checks are not scheduled
+and are run [manually via GitHub Actions](https://github.com/opensafely/documentation/actions/workflows/check_vale.yml).
+
+### URL validity checks
 
 To help keep the content up-to-date,
-this repository has a scheduled weekly link check run with lychee.
+there is a scheduled weekly link check
+run with the [lychee link checker](https://github.com/lycheeverse/lychee/).
 
-### Finding the inaccessible URLs
+The URL check can also be [run manually via GitHub Actions](https://github.com/opensafely/documentation/actions/workflows/check_links.yml).
+
+#### Finding the inaccessible URLs
 
 1. Review the failed workflow output by opening the [workflow runs](https://github.com/opensafely/documentation/actions/workflows/check_links.yml) page
    and clicking on the failed run to see a summary.
@@ -17,7 +44,7 @@ this repository has a scheduled weekly link check run with lychee.
    URLs might fail for one of several reasons.
    It is worth checking whether the URL can be viewed in browser.
 
-### Addressing inaccessible URLs
+#### Addressing inaccessible URLs
 
 Here is a non-exhaustive list of common failures
 and how to address them
@@ -49,7 +76,7 @@ and how to address them
 * :heavy_check_mark: **Resolution**: find a replacement URL or remove the URL
   (see ["Replacing inaccessible URLs"](#replacing-inaccessible-urls) below)
 
-### Replacing inaccessible URLs
+#### Replacing inaccessible URLs
 
 There are several options for dealing with a URL that is really no longer accessible,
 and will not be in future:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ To help keep the content up-to-date,
 there is a scheduled weekly link check
 run with the [lychee link checker](https://github.com/lycheeverse/lychee/).
 
+This detects broken links:
+URLs whose resources are no longer accessible.
+
 The URL check can also be [run manually via GitHub Actions](https://github.com/opensafely/documentation/actions/workflows/check_links.yml).
 
 #### Finding the inaccessible URLs
@@ -53,13 +56,6 @@ and how to address them
   (the syntax of these can be tricky to get correct)
 * :heavy_check_mark: **Resolution**: edit the documentation to correct the link
 <!-- -->
-* :mag:**Cause**: the resource that the URL points to either:
-  * has restricted permissions
-    (for example, requires you to login to see it)
-  * or, is not restricted to a real web browser user,
-    but is inaccessible by the Lychee client and/or the GitHub Actions runner
-* :heavy_check_mark: **Resolution**: add the URL to the `.lycheeignore` file
-<!-- -->
 * :mag:**Cause**: a broken URL due to the resource being unavailable,
   due to the site having an outage or maintenance period
 * :heavy_check_mark: **Resolution**: leave and review in the next link check a week later;
@@ -67,14 +63,21 @@ and how to address them
   consider finding a replacement URL or removing the URL
   (see ["Replacing inaccessible URLs"](#replacing-inaccessible-urls) below)
 <!-- -->
+* :mag:**Cause**: the resource the URL identifies has genuinely been removed
+* :heavy_check_mark: **Resolution**: find a replacement URL or remove the URL
+  (see ["Replacing inaccessible URLs"](#replacing-inaccessible-urls) below)
+<!-- -->
 * :mag:**Cause**: the lychee client gets rate limited by a particular site,
   resulting in a failed check
 * :heavy_check_mark: **Resolution**: reconfigure the link check workflow with lychee's `--max-concurrency` option
   and reduce it from the default value
 <!-- -->
-* :mag:**Cause**: the resource the URL identifies has genuinely been removed
-* :heavy_check_mark: **Resolution**: find a replacement URL or remove the URL
-  (see ["Replacing inaccessible URLs"](#replacing-inaccessible-urls) below)
+* :mag:**Cause**: the resource that the URL points to either:
+  * has restricted permissions
+    (for example, requires you to login to see it)
+  * or, is not restricted to a real web browser user,
+    but is inaccessible by the Lychee client and/or the GitHub Actions runner
+* :heavy_check_mark: **Resolution**: add the URL to the `.lycheeignore` file
 
 #### Replacing inaccessible URLs
 

--- a/justfile
+++ b/justfile
@@ -107,6 +107,10 @@ fetch-cohort-extractor:
 update-cohort-extractor:
     git submodule update --remote src/cohort-extractor
 
+# Requires Vale: https://github.com/errata-ai/vale
+lint-docs:
+    vale ./docs
+
 # Run the tests
 test: devenv
     echo "Not implemented here"

--- a/styles/OpenSAFELY/Branding.yml
+++ b/styles/OpenSAFELY/Branding.yml
@@ -1,10 +1,11 @@
 extends: substitution
-message: Consider using '%s' instead of '%s'
+scope: text
+message: "Consider using '%s' instead of '%s'"
 level: suggestion
 ignorecase: true
 # swap maps tokens in form of bad: good
 swap:
   # NOTE: The left-hand (bad) side can match the right-hand (good) side; Vale
   # will ignore any alerts that match the intended form.
-  "github": GitHub
-  "open[ -]?safely": OpenSAFELY
+  'github(?!.com)': 'GitHub'
+  'open[ -]?safely(?!.org)': 'OpenSAFELY'

--- a/styles/OpenSAFELY/Branding.yml
+++ b/styles/OpenSAFELY/Branding.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: Consider using '%s' instead of '%s'
+level: suggestion
+ignorecase: true
+# swap maps tokens in form of bad: good
+swap:
+  # NOTE: The left-hand (bad) side can match the right-hand (good) side; Vale
+  # will ignore any alerts that match the intended form.
+  "github": GitHub
+  "open[ -]?safely": OpenSAFELY

--- a/styles/OpenSAFELY/HereLinks.yml
+++ b/styles/OpenSAFELY/HereLinks.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: Consider rewording link text to remove the use of 'here'
+scope: raw
+level: warning
+ignorecase: true
+raw:
+  - '\[.*here.*\]'

--- a/styles/OpenSAFELY/HereLinks.yml
+++ b/styles/OpenSAFELY/HereLinks.yml
@@ -1,7 +1,7 @@
 extends: existence
-message: Consider rewording link text to remove the use of 'here'
 scope: raw
-level: warning
+message: 'Consider rewording link text to remove the use of "here"'
+level: suggestion
 ignorecase: true
 raw:
-  - '\[.*here.*\]'
+  - '(\[|\[.*\s)here(\s.*)?\]'

--- a/styles/OpenSAFELY/InternalLinks.yml
+++ b/styles/OpenSAFELY/InternalLinks.yml
@@ -1,8 +1,8 @@
 extends: existence
 message: 'Links to other documentation pages should be written with a relative file path, not a link to a specific domain'
 link: 'https://www.mkdocs.org/user-guide/writing-your-docs/#linking-to-pages'
-level: warning
-ignorecase: true
 scope: raw
+level: suggestion
+ignorecase: true
 raw:
   - '[(<].*docs.opensafely.org.*[)>]'

--- a/styles/OpenSAFELY/InternalLinks.yml
+++ b/styles/OpenSAFELY/InternalLinks.yml
@@ -1,0 +1,8 @@
+extends: existence
+message: 'Links to other documentation pages should be written with a relative file path, not a link to a specific domain'
+link: 'https://www.mkdocs.org/user-guide/writing-your-docs/#linking-to-pages'
+level: warning
+ignorecase: true
+scope: raw
+raw:
+  - '[(<].*docs.opensafely.org.*[)>]'


### PR DESCRIPTION
Fixes #1289.
Fixes #1291.
Relates to #519 and #643.

This adds a minimal Vale configuration as a trial.

With this change, adding rules can help us be more consistent across our documentation. These are not enforced anywhere, but can be checked optionally by one or more of:

* running Vale locally against the documentation source via `just lint-docs`
* installing Vale into editor/IDE for suggestions while editing
* running the `check_docs` workflow, included in this PR that allows you to list the suggestions for a branch

The rules may still need further refinement especially as they are regex-based, but they are not enforced anywhere.

Running Vale with these rules on the documentation source results in 0 suggestions, since these were fixed in #1304.

:warning: This PR *does not*:

* add some automated way of installing Vale locally; individuals must do that themselves.
* check the ehrQL documentation; that will need some thinking about integration, particularly because:
  * ehrQL documentation is pulled in separately from the ehrQL repository
  * a sizeable chunk of the ehrQL documentation is autogenerated from Python docstrings