### PR TITLE
Tidy 'publication of outputs on jobserver' sections

### DIFF
--- a/docs/jobs-site.md
+++ b/docs/jobs-site.md
@@ -164,9 +164,9 @@ For instructions on how to request approval, please see [this section](https://w
 
 Following approval from NHSE, you should also publish your released results on [https://jobs.opensafely.org/](https://jobs.opensafely.org/). To do this, navigate to 'All outputs' which contains your latest outputs from within the "Released outputs" section of your workspace and click the `Publish` button. This will create a draft public output for review by the OpenSAFELY team; contact your co-pilot to prompt review. It is currently only possible to publish the latest version of all of these files. If you do not want to publish all of the latest outputs, please discuss this with your co-pilot.
 
-As part of publishing your outputs, you should also make the repository where your analysis code is written public. Refer to the [instructions on doing so](project-completion.md).
-
 Once approved, your released outputs will be “published” and viewable from the published outputs in the `Published outputs` section of your `Releases`. This is accessible by everyone, even those without a login.
+
+As part of publishing your outputs, you should also make the repository where your analysis code is written public. Refer to the [instructions on doing so](project-completion.md).
 
 
 ## Updating project status

--- a/docs/jobs-site.md
+++ b/docs/jobs-site.md
@@ -160,8 +160,9 @@ Once reviewed, approved and released, your requested files will be available to 
 ## Publishing outputs
 
 You must seek NHS England approval for any publication or wider sharing of results, papers, presentations (e.g. submitting to a journal or a pre-print server, or uploading to any public facing website).
+For instructions on how to request approval, please see [this section](https://www.opensafely.org/policies-for-researchers/#all-datasets-publication) of the researcher policy document. 
 
-For instructions on how to request approval, please see [this section](https://www.opensafely.org/policies-for-researchers/#all-datasets-publication) of the researcher policy document. Following approval from NHSE, you should also create draft public outputs for review. To do this, navigate to 'All outputs' which contains your latest outputs from within the "Released outputs" section of your workspace and click the `Publish` button. It is currently only possible to publish the latest version of all of these files.
+Following approval from NHSE, you should also publish your released results on [https://jobs.opensafely.org/](https://jobs.opensafely.org/). To do this, navigate to 'All outputs' which contains your latest outputs from within the "Released outputs" section of your workspace and click the `Publish` button. This will create a draft public output for review by the OpenSAFELY team; contact your co-pilot to prompt review. It is currently only possible to publish the latest version of all of these files. If you do not want to publish all of the latest outputs, please discuss this with your co-pilot.
 
 As part of publishing your outputs, you should also make the repository where your analysis code is written public. Refer to the [instructions on doing so](project-completion.md).
 

--- a/docs/project-completion.md
+++ b/docs/project-completion.md
@@ -59,7 +59,8 @@ Consider [obtaining a DOI for your releases](https://guides.github.com/activitie
 
 ## Update project workspaces
 
-[Update the purposes of your project workspaces](jobs-site.md#adding-a-workspace-purpose) on the Jobs site.
+Ensure each Workspace in your project on the Jobs site has a _purpose_ and [update if necessary](jobs-site.md#adding-a-workspace-purpose).
+
 ## Request the repo is made public
 
 If your repository is *private*, you can request it is made public via the jobs site.
@@ -72,7 +73,8 @@ Once you have completed this page it will be checked by the OpenSAFELY team befo
 
 ## Make your outputs on the jobs site public
 
-Consider making all outputs released to the project workspace on the jobs site "published". You can publish outputs from the "latest" release in the `Released Outputs` section of your workspace. When you click publish, *all* of the latest outputs will be made public. If you do not want to publish all of the latest outputs, you should discuss this with your co-pilot.
+Consider making all outputs released to the project workspace on the jobs site "published". You can publish outputs from the "latest" release in the `Released Outputs` section of your workspace. When you click publish, *all* of the outputs will be made public (but only the latest version of each). The published results will appear as a draft until checked and approved by the OpenSAFELY team (your co-pilot should ensure this is completed). If you do not want to publish all of the latest outputs, you should discuss this with your co-pilot.
+
 ## Add your publication to the OpenSAFELY website
 
 Refer to our guidance on [adding a publication to the OpenSAFELY website](adding-a-paper.md).

--- a/docs/project-completion.md
+++ b/docs/project-completion.md
@@ -73,7 +73,7 @@ Once you have completed this page it will be checked by the OpenSAFELY team befo
 
 ## Make your outputs on the jobs site public
 
-Once you have approval from NHSE to publish your work, consider making all outputs released to the project workspace on the jobs site "published". You can publish outputs from the "latest" release in the `Released Outputs` section of your workspace. When you click publish, *all* of the outputs will be made public (but only the latest version of each). The published results will appear as a draft until checked and approved by the OpenSAFELY team (your co-pilot should ensure this is completed). If you do not want to publish all of the latest outputs, you should discuss this with your co-pilot.
+Once you have approval from NHSE to publish your work, consider making all outputs released to the project workspace on the jobs site "published". See instructions [here](jobs-site/#publishing-outputs). If you do not want to publish all of the latest outputs, you should discuss this with your co-pilot.
 
 ## Add your publication to the OpenSAFELY website
 

--- a/docs/project-completion.md
+++ b/docs/project-completion.md
@@ -73,7 +73,7 @@ Once you have completed this page it will be checked by the OpenSAFELY team befo
 
 ## Make your outputs on the jobs site public
 
-Consider making all outputs released to the project workspace on the jobs site "published". You can publish outputs from the "latest" release in the `Released Outputs` section of your workspace. When you click publish, *all* of the outputs will be made public (but only the latest version of each). The published results will appear as a draft until checked and approved by the OpenSAFELY team (your co-pilot should ensure this is completed). If you do not want to publish all of the latest outputs, you should discuss this with your co-pilot.
+Once you have approval from NHSE to publish your work, consider making all outputs released to the project workspace on the jobs site "published". You can publish outputs from the "latest" release in the `Released Outputs` section of your workspace. When you click publish, *all* of the outputs will be made public (but only the latest version of each). The published results will appear as a draft until checked and approved by the OpenSAFELY team (your co-pilot should ensure this is completed). If you do not want to publish all of the latest outputs, you should discuss this with your co-pilot.
 
 ## Add your publication to the OpenSAFELY website
 

--- a/docs/project-completion.md
+++ b/docs/project-completion.md
@@ -73,7 +73,7 @@ Once you have completed this page it will be checked by the OpenSAFELY team befo
 
 ## Make your outputs on the jobs site public
 
-Once you have approval from NHSE to publish your work, consider making all outputs released to the project workspace on the jobs site "published". See instructions [here](jobs-site/#publishing-outputs). If you do not want to publish all of the latest outputs, you should discuss this with your co-pilot.
+Once you have approval from NHSE to publish your work, consider making all outputs released to the project workspace on the jobs site "published". See instructions [here](jobs-site/#publishing-outputs). 
 
 ## Add your publication to the OpenSAFELY website
 


### PR DESCRIPTION
Mention that copilot should chase up on outputs being turned from draft to public