### PR TITLE
Remove reference to pinned action versions

### DIFF
--- a/docs/actions-pipelines.md
+++ b/docs/actions-pipelines.md
@@ -64,7 +64,7 @@ Every `project.yaml` requires a `version`, `expectations`, and `actions` section
 In general, actions are composed as follows:
 
 * Each action must be named using a valid YAML key (you won't go wrong with letters, numbers, and underscores) and must be unique.
-* Each action must include a `run` key which includes an officially-supported command and a version (`latest` will always select the most recent version, but following initial development you should specify the version to ensure reproducibility).
+* Each action must include a `run` key which includes an officially-supported command and a version (which at present is usually just `latest`).
     * The `cohortextractor` command has the same options as described in the [cohortextractor section](actions-cohortextractor.md).
     * The `python`, `r`, and `stata-mp` commands provide a locked-down execution environment that can take one or more `inputs` which are passed to the code.
 * Each action must include an `outputs` key with at least one output, classified as either `highly_sensitive` or `moderately_sensitive`


### PR DESCRIPTION
Although we want to move away from `latest` completely, we don't currently supported specifying versions so this parenthetical remark is misleading.

The exception here is `ehrql` which does require a version and doesn't accept `latest` – but I don't think there's any point complicating things at this stage in the text.