### PR TITLE
Update Material for MkDocs emoji config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -178,8 +178,8 @@ markdown_extensions:
   - md_in_html
   - attr_list
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 hooks:
     - hooks/parent_snippets.py


### PR DESCRIPTION
As opensafely-core/ehrql#1678.

Fixes the following warning:

```
WARNING -  Material emoji logic has been officially moved into mkdocs-material
           version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
           as mkdocs_material_extensions is deprecated and will no longer be
           supported moving forward. This is the last release.
```