### PR TITLE
Add note about origin of some APC documentation

### DIFF
--- a/docs/data-sources/apc.md
+++ b/docs/data-sources/apc.md
@@ -28,6 +28,11 @@ The dataset does not include any patients who have not been discharged (i.e., pa
 
 ## Available filters and `returning` fields
 
+!!! note
+
+    The following notes were written for users of [cohort-extractor](study-defs.md)
+    but may be useful to other users as well.
+
 - [Admission date](#admission_date)
 - [Number of matches in period (number of spells)](#number_of_matches_in_period)
 - [Discharge date](#discharge_date)


### PR DESCRIPTION
These docs are good and may provide value to ehrQL users, but there's no good place to put them at the moment, since not everything mentioned here is available via ehrQL.