### PR TITLE
Tell users to tell tech-support when requesting new packages

### DIFF
--- a/docs/requesting-libraries.md
+++ b/docs/requesting-libraries.md
@@ -3,6 +3,9 @@ Installing packages via commands that pull the package from the internet (e.g `i
 
 **Before requesting a new package, please first check whether or not the package has already been installed!** See below for how to do this for specific languages.
 
+To make a request, please open an issue against the relevant GitHub repository (see below for details)
+and let [tech-support](/how-to-get-help#slack) know.
+
 ## R packages
 
 First check that the package is not already available, by [viewing all installed packages and their versions for the


### PR DESCRIPTION
We've turned off the automatic notifications to Slack, because it was too noisy