### PR TITLE
Add OpenSAFELY explainer YouTube video to the home page

### DIFF
--- a/docs/css/lite-yt-embed.css
+++ b/docs/css/lite-yt-embed.css
@@ -1,0 +1,85 @@
+lite-youtube {
+  background-color: #000;
+  position: relative;
+  display: block;
+  contain: content;
+  background-position: center center;
+  background-size: cover;
+  cursor: pointer;
+  max-width: 720px;
+}
+
+/* gradient */
+lite-youtube::before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0;
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAADGCAYAAAAT+OqFAAAAdklEQVQoz42QQQ7AIAgEF/T/D+kbq/RWAlnQyyazA4aoAB4FsBSA/bFjuF1EOL7VbrIrBuusmrt4ZZORfb6ehbWdnRHEIiITaEUKa5EJqUakRSaEYBJSCY2dEstQY7AuxahwXFrvZmWl2rh4JZ07z9dLtesfNj5q0FU3A5ObbwAAAABJRU5ErkJggg==);
+  background-position: top;
+  background-repeat: repeat-x;
+  height: 60px;
+  padding-bottom: 50px;
+  width: 100%;
+  transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
+}
+
+/* responsive iframe with a 16:9 aspect ratio
+  thanks https://css-tricks.com/responsive-iframes/
+*/
+lite-youtube::after {
+  content: "";
+  display: block;
+  padding-bottom: calc(100% / (16 / 9));
+}
+lite-youtube > iframe {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border: 0;
+}
+
+/* play button */
+lite-youtube > .lty-playbtn {
+  display: block;
+  /* Make the button element cover the whole area for a large hover/click target… */
+  width: 100%;
+  height: 100%;
+  /* …but visually it's still the same size */
+  background: no-repeat center/68px 48px;
+  /* YT's actual play button svg */
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"><path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="red"/><path d="M45 24 27 14v20" fill="white"/></svg>');
+  position: absolute;
+  cursor: pointer;
+  z-index: 1;
+  filter: grayscale(100%);
+  transition: filter .1s cubic-bezier(0, 0, 0.2, 1);
+  border: 0;
+}
+
+lite-youtube:hover > .lty-playbtn,
+lite-youtube .lty-playbtn:focus {
+  filter: none;
+}
+
+/* Post-click styles */
+lite-youtube.lyt-activated {
+  cursor: unset;
+}
+lite-youtube.lyt-activated::before,
+lite-youtube.lyt-activated > .lty-playbtn {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.lyt-visually-hidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/docs/css/youtube.css
+++ b/docs/css/youtube.css
@@ -15,3 +15,12 @@
   height: 100%;
   border: 0;
 }
+
+.youtube-embed {
+  display: block;
+  padding: 1rem 0;
+
+  lite-youtube {
+    margin: 0 auto;
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,13 @@ As such, the platform maintains extremely high standards for data privacy whilst
 !!! note "OpenSAFELY is still a relatively new project"
     OpenSAFELY is under constant development; we suggest you regularly check our [Platform News page](https://www.opensafely.org/changelog/) to learn about significant improvements.
 
+<div class="youtube-embed">
+  <lite-youtube
+    videoid="GRjRqOAIVy8"
+    params="controls=1&modestbranding=2&rel=0&enablejsapi=1"
+  ></lite-youtube>
+</div>
+
 ## Who is OpenSAFELY?
 
 OpenSAFELY is a collaboration between the [Bennett Institute for Applied Data Science](https://www.bennett.ox.ac.uk/) at the University of Oxford, the EHR group at London School of Hygiene and Tropical Medicine, TPP and other electronic health record software companies (who already manage NHS patients' records), working on behalf of NHS England.

--- a/docs/js/lite-yt-embed.js
+++ b/docs/js/lite-yt-embed.js
@@ -1,0 +1,166 @@
+/**
+ * A lightweight youtube embed. Still should feel the same to the user, just MUCH faster to initialize and paint.
+ *
+ * Thx to these as the inspiration
+ *   https://storage.googleapis.com/amp-vs-non-amp/youtube-lazy.html
+ *   https://autoplay-youtube-player.glitch.me/
+ *
+ * Once built it, I also found these:
+ *   https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube (👍👍)
+ *   https://github.com/Daugilas/lazyYT
+ *   https://github.com/vb/lazyframe
+ */
+class LiteYTEmbed extends HTMLElement {
+  connectedCallback() {
+      this.videoId = this.getAttribute('videoid');
+
+      let playBtnEl = this.querySelector('.lty-playbtn');
+      // A label for the button takes priority over a [playlabel] attribute on the custom-element
+      this.playLabel = (playBtnEl && playBtnEl.textContent.trim()) || this.getAttribute('playlabel') || 'Play';
+
+      /**
+       * Lo, the youtube placeholder image!  (aka the thumbnail, poster image, etc)
+       *
+       * See https://github.com/paulirish/lite-youtube-embed/blob/master/youtube-thumbnail-urls.md
+       *
+       * TODO: Do the sddefault->hqdefault fallback
+       *       - When doing this, apply referrerpolicy (https://github.com/ampproject/amphtml/pull/3940)
+       * TODO: Consider using webp if supported, falling back to jpg
+       */
+      if (!this.style.backgroundImage) {
+        this.style.backgroundImage = `url("https://i.ytimg.com/vi/${this.videoId}/hqdefault.jpg")`;
+      }
+
+      // Set up play button, and its visually hidden label
+      if (!playBtnEl) {
+          playBtnEl = document.createElement('button');
+          playBtnEl.type = 'button';
+          playBtnEl.classList.add('lty-playbtn');
+          this.append(playBtnEl);
+      }
+      if (!playBtnEl.textContent) {
+          const playBtnLabelEl = document.createElement('span');
+          playBtnLabelEl.className = 'lyt-visually-hidden';
+          playBtnLabelEl.textContent = this.playLabel;
+          playBtnEl.append(playBtnLabelEl);
+      }
+      playBtnEl.removeAttribute('href');
+
+      // On hover (or tap), warm up the TCP connections we're (likely) about to use.
+      this.addEventListener('pointerover', LiteYTEmbed.warmConnections, {once: true});
+
+      // Once the user clicks, add the real iframe and drop our play button
+      // TODO: In the future we could be like amp-youtube and silently swap in the iframe during idle time
+      //   We'd want to only do this for in-viewport or near-viewport ones: https://github.com/ampproject/amphtml/pull/5003
+      this.addEventListener('click', this.addIframe);
+
+      // Chrome & Edge desktop have no problem with the basic YouTube Embed with ?autoplay=1
+      // However Safari desktop and most/all mobile browsers do not successfully track the user gesture of clicking through the creation/loading of the iframe,
+      // so they don't autoplay automatically. Instead we must load an additional 2 sequential JS files (1KB + 165KB) (un-br) for the YT Player API
+      // TODO: Try loading the the YT API in parallel with our iframe and then attaching/playing it. #82
+      this.needsYTApiForAutoplay = navigator.vendor.includes('Apple') || navigator.userAgent.includes('Mobi');
+  }
+
+  /**
+   * Add a <link rel={preload | preconnect} ...> to the head
+   */
+  static addPrefetch(kind, url, as) {
+      const linkEl = document.createElement('link');
+      linkEl.rel = kind;
+      linkEl.href = url;
+      if (as) {
+          linkEl.as = as;
+      }
+      document.head.append(linkEl);
+  }
+
+  /**
+   * Begin pre-connecting to warm up the iframe load
+   * Since the embed's network requests load within its iframe,
+   *   preload/prefetch'ing them outside the iframe will only cause double-downloads.
+   * So, the best we can do is warm up a few connections to origins that are in the critical path.
+   *
+   * Maybe `<link rel=preload as=document>` would work, but it's unsupported: http://crbug.com/593267
+   * But TBH, I don't think it'll happen soon with Site Isolation and split caches adding serious complexity.
+   */
+  static warmConnections() {
+      if (LiteYTEmbed.preconnected) return;
+
+      // The iframe document and most of its subresources come right off youtube.com
+      LiteYTEmbed.addPrefetch('preconnect', 'https://www.youtube-nocookie.com');
+      // The botguard script is fetched off from google.com
+      LiteYTEmbed.addPrefetch('preconnect', 'https://www.google.com');
+
+      // Not certain if these ad related domains are in the critical path. Could verify with domain-specific throttling.
+      LiteYTEmbed.addPrefetch('preconnect', 'https://googleads.g.doubleclick.net');
+      LiteYTEmbed.addPrefetch('preconnect', 'https://static.doubleclick.net');
+
+      LiteYTEmbed.preconnected = true;
+  }
+
+  fetchYTPlayerApi() {
+      if (window.YT || (window.YT && window.YT.Player)) return;
+
+      this.ytApiPromise = new Promise((res, rej) => {
+          var el = document.createElement('script');
+          el.src = 'https://www.youtube.com/iframe_api';
+          el.async = true;
+          el.onload = _ => {
+              YT.ready(res);
+          };
+          el.onerror = rej;
+          this.append(el);
+      });
+  }
+
+  async addYTPlayerIframe(params) {
+      this.fetchYTPlayerApi();
+      await this.ytApiPromise;
+
+      const videoPlaceholderEl = document.createElement('div')
+      this.append(videoPlaceholderEl);
+
+      const paramsObj = Object.fromEntries(params.entries());
+
+      new YT.Player(videoPlaceholderEl, {
+          width: '100%',
+          videoId: this.videoId,
+          playerVars: paramsObj,
+          events: {
+              'onReady': event => {
+                  event.target.playVideo();
+              }
+          }
+      });
+  }
+
+  async addIframe(){
+      if (this.classList.contains('lyt-activated')) return;
+      this.classList.add('lyt-activated');
+
+      const params = new URLSearchParams(this.getAttribute('params') || []);
+      params.append('autoplay', '1');
+      params.append('playsinline', '1');
+
+      if (this.needsYTApiForAutoplay) {
+          return this.addYTPlayerIframe(params);
+      }
+
+      const iframeEl = document.createElement('iframe');
+      iframeEl.width = 560;
+      iframeEl.height = 315;
+      // No encoding necessary as [title] is safe. https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#:~:text=Safe%20HTML%20Attributes%20include
+      iframeEl.title = this.playLabel;
+      iframeEl.allow = 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture';
+      iframeEl.allowFullscreen = true;
+      // AFAIK, the encoding here isn't necessary for XSS, but we'll do it only because this is a URL
+      // https://stackoverflow.com/q/64959723/89484
+      iframeEl.src = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(this.videoId)}?${params.toString()}`;
+      this.append(iframeEl);
+
+      // Set focus for a11y
+      iframeEl.focus();
+  }
+}
+// Register custom element
+customElements.define('lite-youtube', LiteYTEmbed);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,10 +104,12 @@ edit_uri: "edit/main/docs/"
 extra_css:
   - css/youtube.css
   - css/extra.css
+  - css/lite-yt-embed.css
   - ehrql/stylesheets/extra.css
 
 extra_javascript:
   - js/extra.js
+  - js/lite-yt-embed.js
 
 extra:
   social:


### PR DESCRIPTION
And set up `lite-yt-embed` styles and scripts to reduce initial page load size.