### PR TITLE
Remove ehrQL generated docs from built site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,9 @@ site_name: OpenSAFELY documentation
 site_url: !ENV MKDOCS_SITE_URL
 repo_url: https://github.com/opensafely/documentation
 
+exclude_docs: |
+  /ehrql/includes/generated_docs/
+
 nav:
   - Introduction: index.md
   - About OpenSAFELY:


### PR DESCRIPTION
Fixes #1442. Fixes #1402.

The way the site is organised — generated Markdown documents getting included by the actual Markdown documents that include them — means some content is duplicated.

In the site's search, the included document itself may end up appearing ahead of the canonical version that incorporates the included document.