### PR TITLE
Upgrade `mkdocs-autorefs` to 1.0.1

### DIFF
--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -188,6 +188,7 @@ markupsafe==2.1.2 \
     # via
     #   jinja2
     #   mkdocs
+    #   mkdocs-autorefs
     #   mkdocstrings
 mergedeep==1.3.4 \
     --hash=sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8 \
@@ -204,9 +205,9 @@ mkdocs==1.5.3 \
     #   mkdocs-multirepo-plugin
     #   mkdocs-table-reader-plugin
     #   mkdocstrings
-mkdocs-autorefs==0.4.1 \
-    --hash=sha256:70748a7bd025f9ecd6d6feeba8ba63f8e891a1af55f48e366d6d6e78493aba84 \
-    --hash=sha256:a2248a9501b29dc0cc8ba4c09f4f47ff121945f6ce33d760f145d6f89d313f5b
+mkdocs-autorefs==1.0.1 \
+    --hash=sha256:aacdfae1ab197780fb7a2dac92ad8a3d8f7ca8049a9cbe56a4218cd52e8da570 \
+    --hash=sha256:f684edf847eced40b570b57846b15f0bf57fb93ac2c510450775dcf16accb971
     # via mkdocstrings
 mkdocs-macros-plugin==1.0.5 \
     --hash=sha256:f60e26f711f5a830ddf1e7980865bf5c0f1180db56109803cdd280073c1a050a \


### PR DESCRIPTION
It's a transitive dependency, so doesn't get updated by Dependabot with our current configuration (only direct dependencies get updated).

v0.4.1 causes an extra warning on running MkDocs.