### PR TITLE
Fix terminal code copy

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -162,3 +162,7 @@ body {
 .md-header-nav__source .md-source__facts {
   display: none;
 }
+
+.highlight .gp, .highlight .go { /* Generic.Prompt, Generic.Output */
+  user-select: none;
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -234,7 +234,7 @@ account, for developing your own study:
     prompt `$` and pressing ++enter++. You should see an output that looks
     something like:
 
-    ```
+    ```shell-session
     $ opensafely
     usage: opensafely [-h] [--version] COMMAND ...
 
@@ -356,7 +356,7 @@ study.
 Now you're ready to run your first study. Ensure your current directory is your newly-cloned
 study repository, and run:
 
-```sh
+```shell-session
 $ opensafely run run_all
 ```
 
@@ -479,7 +479,7 @@ to the sex of each patient*"; and line 15 "*Give me a column of data correspondi
 to the age of each patient on the given date*".
 3. If you run:
 
-   ```sh
+   ```shell-session
    $ opensafely run run_all
    ```
 
@@ -493,7 +493,7 @@ to the age of each patient on the given date*".
    We can use the `--force-run-dependencies` (or `-f`) option to force
    the CSV file to be created again.
 
-   ```
+   ```shell-session
    $ opensafely run run_all --force-run-dependencies
    ```
 

--- a/docs/install-linux.md
+++ b/docs/install-linux.md
@@ -37,7 +37,7 @@ There are multiple ways you can install Docker:
 It is useful to use [pipx](https://github.com/pypa/pipx) to install Python applications.
 
 pipx installs Python software into a Python virtual environment.
-pipx allows you to isolate Python package installations for different software, 
+pipx allows you to isolate Python package installations for different software,
 and still easily run that software.
 
 Install the [OpenSAFELY CLI](opensafely-cli.md) with pipx:
@@ -63,7 +63,7 @@ pipx install opensafely
 Test the installation of OpenSAFELY CLI.
 This should print out the usage and available sub commands:
 
-```
+``` shell-session
 $ opensafely --help
 usage: opensafely [-h] [--version] COMMAND ...
 

--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -10,23 +10,6 @@ if (document.location.hostname === domain) {
   document.head.appendChild(script);
 }
 
-document.addEventListener("DOMContentLoaded", () => {
-  patchCopyCodeButtons();
-});
-
-function patchCopyCodeButtons() {
-  // select all "copy" buttons whose target selector is a <code> element
-  codeCopyButtons = document.querySelectorAll(
-    'button.md-clipboard[data-clipboard-target$="code"]',
-  );
-  for (const btn of codeCopyButtons) {
-    const codeTextToCopy = getTextWithoutPromptAndOutput(
-      btn.dataset.clipboardTarget,
-    );
-    btn.dataset.clipboardText = codeTextToCopy;
-  }
-}
-
 function getTextWithoutPromptAndOutput(targetSelector) {
   const targetElement = document.querySelector(targetSelector);
 
@@ -45,3 +28,20 @@ function getTextWithoutPromptAndOutput(targetSelector) {
   }
   return text;
 }
+
+function patchCopyCodeButtons() {
+  // select all "copy" buttons whose target selector is a <code> element
+  codeCopyButtons = document.querySelectorAll(
+    'button.md-clipboard[data-clipboard-target$="code"]',
+  );
+  for (const btn of codeCopyButtons) {
+    const codeTextToCopy = getTextWithoutPromptAndOutput(
+      btn.dataset.clipboardTarget,
+    );
+    btn.dataset.clipboardText = codeTextToCopy;
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  patchCopyCodeButtons();
+});

--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -31,15 +31,16 @@ function getTextWithoutPromptAndOutput(targetSelector) {
 
 function patchCopyCodeButtons() {
   // select all "copy" buttons whose target selector is a <code> element
-  codeCopyButtons = document.querySelectorAll(
-    'button.md-clipboard[data-clipboard-target$="code"]',
+  [
+    ...document.querySelectorAll(
+      `button.md-clipboard[data-clipboard-target$="code"]`,
+    ),
+  ].map((btn) =>
+    btn.setAttribute(
+      "data-clipboard-text",
+      getTextWithoutPromptAndOutput(btn.dataset.clipboardTarget),
+    ),
   );
-  for (const btn of codeCopyButtons) {
-    const codeTextToCopy = getTextWithoutPromptAndOutput(
-      btn.dataset.clipboardTarget,
-    );
-    btn.dataset.clipboardText = codeTextToCopy;
-  }
 }
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -1,7 +1,7 @@
-var domain = "docs.opensafely.org";
+const domain = "docs.opensafely.org";
 
 if (document.location.hostname === domain) {
-  var script = document.createElement("script");
+  const script = document.createElement("script");
   script.defer = true;
   script.setAttribute("data-domain", domain);
   script.id = "plausible";
@@ -10,13 +10,19 @@ if (document.location.hostname === domain) {
   document.head.appendChild(script);
 }
 
-document.addEventListener("DOMContentLoaded", function () { patchCopyCodeButtons(); });
+document.addEventListener("DOMContentLoaded", () => {
+  patchCopyCodeButtons();
+});
 
 function patchCopyCodeButtons() {
   // select all "copy" buttons whose target selector is a <code> element
-  codeCopyButtons = document.querySelectorAll('button.md-clipboard[data-clipboard-target$="code"]');
-  for (let btn of codeCopyButtons) {
-    let codeTextToCopy = getTextWithoutPromptAndOutput(btn.dataset.clipboardTarget);
+  codeCopyButtons = document.querySelectorAll(
+    'button.md-clipboard[data-clipboard-target$="code"]',
+  );
+  for (const btn of codeCopyButtons) {
+    const codeTextToCopy = getTextWithoutPromptAndOutput(
+      btn.dataset.clipboardTarget,
+    );
     btn.dataset.clipboardText = codeTextToCopy;
   }
 }
@@ -25,12 +31,14 @@ function getTextWithoutPromptAndOutput(targetSelector) {
   const targetElement = document.querySelector(targetSelector);
 
   // exclude "Generic Prompt" and "Generic Output" spans from copy
-  const excludedClasses = ['gp', 'go'];
+  const excludedClasses = ["gp", "go"];
 
-  let text = '';
+  let text = "";
   for (const node of targetElement.childNodes) {
-    if (node.nodeType == Node.TEXT_NODE |
-      (node.nodeType == Node.ELEMENT_NODE && !excludedClasses.includes(node.className))
+    if (
+      (node.nodeType == Node.TEXT_NODE) |
+      (node.nodeType == Node.ELEMENT_NODE &&
+        !excludedClasses.includes(node.className))
     ) {
       text += node.textContent;
     }

--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -29,7 +29,7 @@ function getTextWithoutPromptAndOutput(targetSelector) {
     return null;
   });
 
-  return clipboardText.join("");
+  return clipboardText.join("").trim();
 }
 
 function patchCopyCodeButtons() {

--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -9,3 +9,31 @@ if (document.location.hostname === domain) {
 
   document.head.appendChild(script);
 }
+
+document.addEventListener("DOMContentLoaded", function () { patchCopyCodeButtons(); });
+
+function patchCopyCodeButtons() {
+  // select all "copy" buttons whose target selector is a <code> element
+  codeCopyButtons = document.querySelectorAll('button.md-clipboard[data-clipboard-target$="code"]');
+  for (let btn of codeCopyButtons) {
+    let codeTextToCopy = getTextWithoutPromptAndOutput(btn.dataset.clipboardTarget);
+    btn.dataset.clipboardText = codeTextToCopy;
+  }
+}
+
+function getTextWithoutPromptAndOutput(targetSelector) {
+  const targetElement = document.querySelector(targetSelector);
+
+  // exclude "Generic Prompt" and "Generic Output" spans from copy
+  const excludedClasses = ['gp', 'go'];
+
+  let text = '';
+  for (const node of targetElement.childNodes) {
+    if (node.nodeType == Node.TEXT_NODE |
+      (node.nodeType == Node.ELEMENT_NODE && !excludedClasses.includes(node.className))
+    ) {
+      text += node.textContent;
+    }
+  }
+  return text;
+}

--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -16,17 +16,20 @@ function getTextWithoutPromptAndOutput(targetSelector) {
   // exclude "Generic Prompt" and "Generic Output" spans from copy
   const excludedClasses = ["gp", "go"];
 
-  let text = "";
-  for (const node of targetElement.childNodes) {
+  const clipboardText = [];
+  [...targetElement.childNodes].map((node) => {
+    // If the element does not contain the matching class,
+    // add to the clipboard text array
     if (
-      (node.nodeType == Node.TEXT_NODE) |
-      (node.nodeType == Node.ELEMENT_NODE &&
-        !excludedClasses.includes(node.className))
+      !excludedClasses.some((className) => node?.classList?.contains(className))
     ) {
-      text += node.textContent;
+      return clipboardText.push(node.textContent);
     }
-  }
-  return text;
+
+    return null;
+  });
+
+  return clipboardText.join("");
 }
 
 function patchCopyCodeButtons() {

--- a/docs/measures.md
+++ b/docs/measures.md
@@ -186,8 +186,8 @@ If the `--output-dir` argument is configured, `generate_measures` expects the in
     As we saw, you can extract the data in a compressed output format, such as `csv.gz`, `feather`, `dta`, or `dta.gz`.
     For example:
 
-    ```sh
-    cohortextractor:latest generate_cohort --output-format=csv.gz
+    ```shell-session
+    $ cohortextractor:latest generate_cohort --output-format=csv.gz
     ```
 
     If you do, then the `generate_measures` command will automatically work with this compressed output format;


### PR DESCRIPTION
Fixes #1458 

* Removes `>>>` and any output lines from copied text when copy button is clicked on a Python code block
* Removes `$` and any output lines from copied text when copy button is clicked on a Shell code block
* Marginally increases page weight and load time: on load every code copy button on the page has an attribute set which contains the "cleaned" code to be copied