### PR TITLE
Fix dummy data population size

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -390,7 +390,7 @@ based on the dataset definition at `analysis/dataset_definition.py`.
 
 To view it, first run `opensafely unzip output`, then open that
 file (by left-clicking the filename in Visual Studio Code's Explorer, or
-software like Excel). You'll see that it contains rows for 500
+software like Excel). You'll see that it contains rows for ten
 randomly-generated dummy patients.
 
 ### Accessing files


### PR DESCRIPTION
We changed the default to ten as part of the v1 release: https://github.com/opensafely-core/ehrql/pull/1811/commits/8ad780c5a65c71279c6a35f693746b276ff0bad3

We've just had an email from a user who was confused by the discrepancy here.