### PR TITLE
Link to explanation from getting started

### DIFF
--- a/docs/getting-started/explanation/index.md
+++ b/docs/getting-started/explanation/index.md
@@ -1,4 +1,4 @@
-This section contains background knowledge on the software used to run OpenSAFELY.
+This section contains background information about the software used to run OpenSAFELY.
 
 * [Options for running OpenSAFELY](options-for-running-opensafely/index.md)
 * [Understanding the software used to run OpenSAFELY](understanding-the-software-used-to-run-opensafely/index.md)

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -8,4 +8,4 @@ All we need is an up to date web browser and an internet connection.
 When you've completed the tutorial,
 browse the [how-to guides](how-to/index.md).
 These provide practical steps for setting up and using OpenSAFELY.
-Finally, the [explanation](explanation/index.md) section contains background knowledge on the software used to run OpenSAFELY.
+Finally, the [explanation](explanation/index.md) section contains background information about the software used to run OpenSAFELY.


### PR DESCRIPTION
We link to the explanation section from the getting started landing page for consistency with the other sections.