### PR TITLE
Add introduction to running OpenSAFELY locally

### DIFF
--- a/docs/getting-started/explanation/index.md
+++ b/docs/getting-started/explanation/index.md
@@ -1,4 +1,4 @@
-This section contains background information about the software used to run OpenSAFELY.
+This section contains background information about running OpenSAFELY.
 
 * [Options for running OpenSAFELY](options-for-running-opensafely/index.md)
 * [Understanding the software used to run OpenSAFELY](understanding-the-software-used-to-run-opensafely/index.md)

--- a/docs/getting-started/how-to/index.md
+++ b/docs/getting-started/how-to/index.md
@@ -6,7 +6,12 @@ The how-to guides provide practical steps for setting up and using OpenSAFELY.
 * [How to use GitHub and Git](../../install-github-and-git.md)
 * [How to use the OpenSAFELY command-line interface](../../opensafely-cli.md)
 
-## Setting up OpenSAFELY
+## Running OpenSAFELY on your computer
+
+All we need to get started with OpenSAFELY is an up to date web browser and an internet connection.
+At some point, however, you may need to run OpenSAFELY on your computer.
+This is sometimes referred to as running OpenSAFELY *locally*
+and can be worthwhile when you don't have a reliable internet connection.
 
 * How to install Python on
     [Windows](../../install-python.md#windows),

--- a/docs/getting-started/how-to/index.md
+++ b/docs/getting-started/how-to/index.md
@@ -8,7 +8,7 @@ The how-to guides provide practical steps for setting up and using OpenSAFELY.
 
 ## Running OpenSAFELY on your computer
 
-All we need to get started with OpenSAFELY is an up to date web browser and an internet connection.
+All you need to get started with OpenSAFELY is an up to date web browser and an internet connection.
 At some point, however, you may need to run OpenSAFELY on your computer.
 This is sometimes referred to as running OpenSAFELY *locally*
 and can be worthwhile when you don't have a reliable internet connection.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,9 +1,9 @@
 This section contains information that will help you get started with OpenSAFELY.
 
 First, complete the [tutorial](tutorial/index.md).
-In the tutorial, we will create a study that uses dummy patient data.
+In the tutorial, you will create a study that uses dummy patient data.
 Because the study uses dummy patient data, anyone can complete the tutorial.
-All we need is an up to date web browser and an internet connection.
+All you need is an up to date web browser and an internet connection.
 
 When you've completed the tutorial,
 browse the [how-to guides](how-to/index.md).

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -8,4 +8,4 @@ All you need is an up to date web browser and an internet connection.
 When you've completed the tutorial,
 browse the [how-to guides](how-to/index.md).
 These provide practical steps for setting up and using OpenSAFELY.
-Finally, the [explanation](explanation/index.md) section contains background information about the software used to run OpenSAFELY.
+Finally, the [explanation](explanation/index.md) section contains background information about running OpenSAFELY.

--- a/docs/getting-started/tutorial/index.md
+++ b/docs/getting-started/tutorial/index.md
@@ -1,5 +1,5 @@
-In the tutorial, we will create a study that uses dummy patient data.
-We will:
+In the tutorial, you will create a study that uses dummy patient data.
+You will:
 
 1. Create a GitHub account
 2. Create a new repository
@@ -9,7 +9,7 @@ We will:
 6. Run the study in a testing environment
 
 Because the study uses dummy patient data, anyone can complete the tutorial.
-All we need is an up to date web browser and an internet connection.
+All you need is an up to date web browser and an internet connection.
 
 ---
 


### PR DESCRIPTION
This is a brief introduction to running OpenSAFELY locally, intended to highlight that the "old" approach exists. Reworking the installation instructions for Python, Docker, and `opensafely` is not in scope.

Closes opensafely-core/codespaces-initiative#15

