### PR TITLE
Remove RStudio login instructions

### DIFF
--- a/docs/getting-started/how-to/use-github-codespaces-in-your-project/index.md
+++ b/docs/getting-started/how-to/use-github-codespaces-in-your-project/index.md
@@ -150,9 +150,4 @@ The research code repository that you created already has a minimal, working Ope
 1. Port 8787 should be listed —
    this is configured by the RStudio server.
 1. Right-click on port 8787 and select "Open in browser".
-1. A new browser tab/window appears with RStudio running
-   prompting you to "Sign in to RStudio".
-   To sign in,
-   enter the username: `rstudio`
-   and the password: `rstudio`
-   and then press "Sign in".
+1. A new browser tab/window appears with RStudio running.


### PR DESCRIPTION
RStudio server is configured to run without needing authentication as of [this](https://github.com/opensafely-core/research-template-docker/commit/cdd84e6e5fcce8eb95826882da6e170f7e69ab68) commit. This change removes the instruction to log in to RStudio as the user is no longer prompted with a login screen.