### PR TITLE
Add "Previous" and "Next" links to tutorial pages

### DIFF
--- a/docs/getting-started/tutorial/add-a-scripted-action-to-the-pipeline/index.md
+++ b/docs/getting-started/tutorial/add-a-scripted-action-to-the-pipeline/index.md
@@ -133,3 +133,8 @@ or right-click on `report.png` and select Download to download the image.
     Changes you make to files are automatically saved on GitHub. However, changes will not persist
     outside of the GitHub codespace unless you *commit* and *push* them to GitHub, as described
     in the next section.
+
+---
+
+* Previous: [Run the project pipeline](../run-the-project-pipeline/index.md)
+* Next: [Publish the changes to GitHub](../publish-the-changes-to-github/index.md)

--- a/docs/getting-started/tutorial/check-the-automated-tests-pass/index.md
+++ b/docs/getting-started/tutorial/check-the-automated-tests-pass/index.md
@@ -12,3 +12,8 @@ commit. The workflow verifies that the command `opensafely run run_all` can
 run successfully. If it's yellow, it's still running. If it's red, it
 has failed. If it's green, it has succeeded. You want it to be green!
 ![The GitHub Actions tab showing a successful workflow.](../../../images/getting-started-github-actions-workflow-success.png)
+
+---
+
+* Previous: [Publish the changes to GitHub](../publish-the-changes-to-github/index.md)
+* Next: [Delete the GitHub codespace](../delete-the-github-codespace/index.md)

--- a/docs/getting-started/tutorial/create-a-github-account/index.md
+++ b/docs/getting-started/tutorial/create-a-github-account/index.md
@@ -23,3 +23,8 @@ to visit to confirm your account.
 
 We recommend that you [secure your GitHub account with two-factor
 authentication](https://docs.github.com/en/github/authenticating-to-github/securing-your-account-with-two-factor-authentication-2fa).
+
+---
+
+* Previous: [Introduction](../introduction/index.md)
+* Next: [Create a GitHub repository](../create-a-github-repository/index.md)

--- a/docs/getting-started/tutorial/create-a-github-codespace/index.md
+++ b/docs/getting-started/tutorial/create-a-github-codespace/index.md
@@ -63,3 +63,8 @@ available commands:
     pull      Command for updating the docker images used to run OpenSAFELY studies locally
     upgrade   Upgrade the opensafely cli tool.
 ```
+
+---
+
+* Previous: [Create a GitHub repository](../create-a-github-repository/index.md)
+* Next: [Generate a first dataset](../generate-a-first-dataset/index.md)

--- a/docs/getting-started/tutorial/create-a-github-repository/index.md
+++ b/docs/getting-started/tutorial/create-a-github-repository/index.md
@@ -17,3 +17,8 @@ account, for developing your own study:
    repository.
 
    If you see `${GITHUB_REPOSITORY_NAME}` in your README, the repo is not yet initialised, wait a few seconds longer and reload.
+
+---
+
+* Previous: [Create a GitHub account](../create-a-github-account/index.md)
+* Next: [Create a GitHub codespace](../create-a-github-codespace/index.md)

--- a/docs/getting-started/tutorial/delete-the-github-codespace/index.md
+++ b/docs/getting-started/tutorial/delete-the-github-codespace/index.md
@@ -3,3 +3,8 @@
 If you close a Codespace in your browser, it still continues running. So, once you've finished using your Codespace, you can delete it.
 
 There's information about how to do this on our [Codespaces](../../how-to/use-github-codespaces-in-your-project/index.md#how-to-delete-a-codespace) page.
+
+---
+
+* Previous: [Check the automated tests pass](../check-the-automated-tests-pass/index.md)
+* Next: [See the next steps](../see-the-next-steps/index.md)

--- a/docs/getting-started/tutorial/generate-a-first-dataset/index.md
+++ b/docs/getting-started/tutorial/generate-a-first-dataset/index.md
@@ -42,3 +42,8 @@ Notice the columns: `patient_id` and `sex`.
 
 In the next part of the tutorial,
 we will see how to add another data column.
+
+---
+
+* Previous: [Create a GitHub codespace](../create-a-github-codespace/index.md)
+* Next: [Update the dataset definition](../update-the-dataset-definition/index.md)

--- a/docs/getting-started/tutorial/introduction/index.md
+++ b/docs/getting-started/tutorial/introduction/index.md
@@ -39,3 +39,7 @@ The tutorial will be completed in the GitHub Codespaces environment.
 Free GitHub accounts are given a monthly quota of Codespaces.
 If you do not have a GitHub account,
 we will create one in this tutorial.
+
+---
+
+* Next: [Create a GitHub account](../create-a-github-account/index.md)

--- a/docs/getting-started/tutorial/publish-the-changes-to-github/index.md
+++ b/docs/getting-started/tutorial/publish-the-changes-to-github/index.md
@@ -77,3 +77,8 @@ The repository was created at:
 If you now visit the repository on the main GitHub site,
 you should see the updated state of the repository
 with the changes you made in the codespace.
+
+---
+
+* Previous: [Add a scripted action to the pipeline](../add-a-scripted-action-to-the-pipeline/index.md)
+* Next: [Check the automated tests pass](../check-the-automated-tests-pass/index.md)

--- a/docs/getting-started/tutorial/run-the-project-pipeline/index.md
+++ b/docs/getting-started/tutorial/run-the-project-pipeline/index.md
@@ -106,3 +106,8 @@ The difference between them is that:
 * `opensafely run` runs actions *inside* the project pipeline,
   that is, just as they would be in the secure OpenSAFELY environment
   containing real patient data
+
+---
+
+* Previous: [Update the dataset definition](../update-the-dataset-definition/index.md)
+* Next: [Add a scripted action to the pipeline](../add-a-scripted-action-to-the-pipeline/index.md)

--- a/docs/getting-started/tutorial/see-the-next-steps/index.md
+++ b/docs/getting-started/tutorial/see-the-next-steps/index.md
@@ -26,3 +26,7 @@ We also recommend:
 
 * [OpenSAFELY Jobs](https://jobs.opensafely.org)
 * [the Visual Studio Code introduction to Git](https://code.visualstudio.com/docs/sourcecontrol/intro-to-git)
+
+---
+
+* Previous: [Delete the GitHub codespace](../delete-the-github-codespace/index.md)

--- a/docs/getting-started/tutorial/update-the-dataset-definition/index.md
+++ b/docs/getting-started/tutorial/update-the-dataset-definition/index.md
@@ -41,3 +41,8 @@ to the age of each patient on the given date*".
    you will see a new randomly generated dataset.
 
    However, this time it contains the additional `age` column.
+
+---
+
+* Previous: [Generate a first dataset](../generate-a-first-dataset/index.md)
+* Next: [Run the project pipeline](../run-the-project-pipeline/index.md)


### PR DESCRIPTION
This adds "Previous" and "Next" links to the body of each page in the tutorial, as the Material for MkDocs "Previous" and "Next" links are easy to miss. It intentionally doesn't add "Up" links, as Material for MkDocs can't decide whether pages exist in one dimension or two.

Thanks for suggesting these, @sebbacon.

Closes #1518