### PR TITLE
Fix "Commit and push" section

### DIFF
--- a/docs/getting-started/how-to/add-github-codespaces-to-your-project/index.md
+++ b/docs/getting-started/how-to/add-github-codespaces-to-your-project/index.md
@@ -66,12 +66,13 @@ git switch --create=github-codespaces
     then create one.
     It's important that it starts with a dot (`.`).
 
-### Commit and push
+### Add, commit, and push
 
-Commit the files you copied in the previous step:
+Add and commit the files you copied in the previous step:
 
 ```sh
-git commit --message='Add GitHub Codespaces'
+git add .
+git commit --message="Add GitHub Codespaces"
 ```
 
 Push to GitHub:


### PR DESCRIPTION
The "Commit and push" section was missing an "add" step. Thanks for spotting this, @alschaffer.

It's not possible to stage and commit untracked files with a single command (i.e. `git commit --all` only stages files that were tracked), so we add an "add" step rather than update the "commit" step.