### PR TITLE
Describe how to handle `.gitignore`

### DIFF
--- a/docs/getting-started/how-to/add-github-codespaces-to-your-project/index.md
+++ b/docs/getting-started/how-to/add-github-codespaces-to-your-project/index.md
@@ -61,6 +61,23 @@ git switch --create=github-codespaces
 * Repeat for the remaining files.
 * Copy each file to the `.devcontainer` folder in your project.
 
+!!! warn "Dotfiles and `.gitignore`"
+    Dotfiles are files and folders that start with a dot (`.`).
+    Many tools for browsing files and folders,
+    such as File Explorer on Windows or Finder on macOS,
+    hide dotfiles by default, so as not to clutter the display.
+
+    GitHub shows dotfiles, but removes the dots when they are downloaded.
+    Whilst this behaviour is understandable,
+    it is also unhelpful,
+    as the dots are important.
+
+    The `.devcontainer` folder contains one dotfile;
+    it's called `.gitignore` and specifies files that Git should ignore.
+    Having downloaded `gitignore` (without the dot) from GitHub
+    and copied it to the `.devcontainer` folder in your project,
+    you should rename it `.gitignore` (with the dot).
+
 !!! info "My project doesn't have a `.devcontainer` folder"
     If your project doesn't have a `.devcontainer` folder,
     then create one.


### PR DESCRIPTION
The "How to add GitHub Codespaces to your project" section instructs a user to download files from opensafely/research-template and copy them to their project. One file in this folder is a dotfile: `.gitignore`. However, the "Download raw file" button removes the dot.

Here, we work around this understandable/unhelpful behaviour by asking the user to rename `gitignore` to `.gitignore`. We deliberately avoid describing *how* to do so, because operating systems, tools, and set-ups vary.

Closes #1533