### PR TITLE
Fix "Push to GitHub" section

### DIFF
--- a/docs/getting-started/how-to/add-github-codespaces-to-your-project/index.md
+++ b/docs/getting-started/how-to/add-github-codespaces-to-your-project/index.md
@@ -95,7 +95,7 @@ git commit --message="Add GitHub Codespaces"
 Push to GitHub:
 
 ```sh
-git push
+git push --set-upstream
 ```
 
 ### Create a pull request


### PR DESCRIPTION
If the user doesn't have `push.autoSetupRemote` set to `true` in their `.gitconfig`, then this step will error with "The current branch <branch> has no upstream branch", which is confusing.

Thanks for reporting this, @rose-higgins.