### PR TITLE
Reinstate bare minimum instructions for adding a paper

### DIFF
--- a/docs/adding-a-paper.md
+++ b/docs/adding-a-paper.md
@@ -1,0 +1,4 @@
+# Adding an OpenSAFELY paper to OpenSAFELY.org
+
+This process is managed by Bennett Institute staff members,
+who may find the relevant instructions in the Bennett Team Manual.


### PR DESCRIPTION
The full instructions have been moved to the internal team manual.

Google will still return search results for the old public-facing instructions at this URL.

To avoid 404 errors, this page is recreated and points anyone who ends up there to the internal docs.

This page is not added back into the menu as we do not believe it is neccesary for non-Bennett users to find it.

Fixes #1550 