### PR TITLE
Reinstate `docs/adding-a-paper.md`

### DIFF
--- a/docs/adding-a-paper.md
+++ b/docs/adding-a-paper.md
@@ -2,39 +2,21 @@
 
 We are very keen to compile all pre-printed and published OpenSAFELY studies on [opensafely.org](https://www.opensafely.org).
 
-To do this, open a new file in a text editor of your choice. Populate the file using the following template:
+To do this, we require the following information:
 
-```
----
-title: "Short title for the page"
-date: yyyy-mm-dd
-status: "preprint" or "published"
-paper: "Title of the paper"
-description: "Description of the paper"
-cite: "How to cite this paper"
-link: "https://doi.org/..."
-project: Approved project number (see https://www.opensafely.org/approved-projects/)
-repo: "OpenSAFELY GitHub repository name"
----
+* the full title
+* the date the paper was published on the journal's website
+* the authors
+* the full citation
+* a short description
+* the DOI
+* the name of the journal
+* the URL of the associated OpenSAFELY repository
+* the number of the associated OpenSAFELY project (see the "[Approved Projects](https://www.opensafely.org/approved-projects/)" page)
 
-## Abstract
+If the paper has an accompanying preprint,
+then we also require the following information about the accompanying preprint:
 
-### Background
-
-### Methods
-
-### Results
-
-### Conclusions
-
-```
-
-First, update the frontmatter (i.e., the text between the `---`s) with the correct details for your paper. Note that `status:` should have the value `preprint` or `published` to indicate the current status of your manuscript. Then, add the necessary text below the `## Abstract` line to include the abstract.
-
-This file format is called "Markdown", for more help writing Markdown documents, see:
-
-- [Markdown Guide: Basic Syntax](https://www.markdownguide.org/basic-syntax/)
-- [Markdown Guide: Cheat Sheet](https://www.markdownguide.org/cheat-sheet/)
-- [Dillinger: this shows a preview of your Markdown as you type](https://dillinger.io/)
-
-This file can then be incorporated into our website by anyone with the required access; if you are an external researcher, then you can send this to your co-pilot who will have the necessary permissions.
+* the full title
+* the DOI
+* the URL

--- a/docs/adding-a-paper.md
+++ b/docs/adding-a-paper.md
@@ -1,4 +1,0 @@
-# Adding an OpenSAFELY paper to OpenSAFELY.org
-
-This process is managed by Bennett Institute staff members,
-who may find the relevant instructions in the Bennett Team Manual.

--- a/docs/adding-a-paper.md
+++ b/docs/adding-a-paper.md
@@ -1,0 +1,40 @@
+# Adding an OpenSAFELY paper to OpenSAFELY.org
+
+We are very keen to compile all pre-printed and published OpenSAFELY studies on [opensafely.org](https://www.opensafely.org).
+
+To do this, open a new file in a text editor of your choice. Populate the file using the following template:
+
+```
+---
+title: "Short title for the page"
+date: yyyy-mm-dd
+status: "preprint" or "published"
+paper: "Title of the paper"
+description: "Description of the paper"
+cite: "How to cite this paper"
+link: "https://doi.org/..."
+project: Approved project number (see https://www.opensafely.org/approved-projects/)
+repo: "OpenSAFELY GitHub repository name"
+---
+
+## Abstract
+
+### Background
+
+### Methods
+
+### Results
+
+### Conclusions
+
+```
+
+First, update the frontmatter (i.e., the text between the `---`s) with the correct details for your paper. Note that `status:` should have the value `preprint` or `published` to indicate the current status of your manuscript. Then, add the necessary text below the `## Abstract` line to include the abstract.
+
+This file format is called "Markdown", for more help writing Markdown documents, see:
+
+- [Markdown Guide: Basic Syntax](https://www.markdownguide.org/basic-syntax/)
+- [Markdown Guide: Cheat Sheet](https://www.markdownguide.org/cheat-sheet/)
+- [Dillinger: this shows a preview of your Markdown as you type](https://dillinger.io/)
+
+This file can then be incorporated into our website by anyone with the required access; if you are an external researcher, then you can send this to your co-pilot who will have the necessary permissions.

--- a/docs/project-completion.md
+++ b/docs/project-completion.md
@@ -74,3 +74,7 @@ Once you have completed this page it will be checked by the OpenSAFELY team befo
 ## Make your outputs on the jobs site public
 
 Once you have approval from NHSE to publish your work, consider making all outputs released to the project workspace on the jobs site "published". See the [publication instructions](jobs-site.md#publishing-outputs).
+
+## Add your publication to the OpenSAFELY website
+
+Refer to our guidance on [adding a publication to the OpenSAFELY website](adding-a-paper.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
       - Managing your OpenSAFELY project:
         - Telling us about changes to your project: project-changes.md
         - Project completion: project-completion.md
+      - Adding your pre-print/paper to OpenSAFELY.org: adding-a-paper.md
       - Information for system integrators: system-integration.md
       - Legacy:
         - Study definitions:


### PR DESCRIPTION
Adds the information that pilots should provide to co-pilots, so that co-pilots can follow the instructions in <https://bennettinstitute-team-manual.pages.dev/products/bennett-ox-ac-uk/#add-a-paper>.

Fixes #1550