### PR TITLE
Notify the tech support channel on failed link checks

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Check links
         uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621  # v1.10.0
         with:
-          args: "--exclude-all-private --exclude-mail --include-verbatim --max-concurrency 24 --require-https --verbose --no-progress --timeout 60 './docs/**/*.md' './docs/**/*.html' './imported_docs/**/*.md' './imported_docs/**/*.html' --exclude-path './docs/ehrql/includes/generated_docs'"
+          args: "--exclude-all-private --include-verbatim --max-concurrency 24 --require-https --verbose --no-progress --timeout 60 './docs/**/*.md' './docs/**/*.html' './imported_docs/**/*.md' './imported_docs/**/*.html' --exclude-path './docs/ehrql/includes/generated_docs'"
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -53,6 +53,6 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
-          channel_id: C069SADHP1Q
+          channel_id: C0270Q313H7
           status: "Check Docs Links Failure"
           color: danger


### PR DESCRIPTION
This is as part of #1419.

The intent is to eventually move this process to being a tech support activity.