### PR TITLE
Notify Slack on failed scheduled link checks only

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -48,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: "Notify Slack on Failure"
-        if: failure()
+        if: ${{ failure() && github.event_name == 'schedule' }}
         uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # v1.6.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
This avoids manually triggered checks sending noise to Slack, which is particularly annoying if fixing the link check requires multiple runs in doing so.

This also explicitly marks the `if` condition as an expression, which is the default behaviour for `if`, but marking as such makes it clearer that it is an expression.