### PR TITLE
Set Permissions-Policy to disable Topics

### DIFF
--- a/docs/_headers
+++ b/docs/_headers
@@ -1,0 +1,2 @@
+/*
+  Permissions-Policy: browsing-topics=()


### PR DESCRIPTION
We set the Permissions-Policy header to disable Topics, which replace Google's [Federated Learning of
Cohorts](https://privacysandbox.com/proposals/floc/) (FLoC). For more information, see: ebmdatalab/sysadmin#354.