### PR TITLE
Update notes on Python Docker image

### DIFF
--- a/docs/actions-reusable.md
+++ b/docs/actions-reusable.md
@@ -81,7 +81,7 @@ if __name__ == "__main__":
 When developing a reusable action, just as when developing a scripted action, the action's dependencies are made available by the runtime; they are not made available by the action.
 
 * The Python runtime is provided by [`python-docker`](https://github.com/opensafely-core/python-docker).
-  Its dependencies are in [*requirements.txt*](https://github.com/opensafely-core/python-docker/blob/main/v1/requirements.txt).
+  Its dependencies are in [*requirements.txt*](https://github.com/opensafely-core/python-docker/blob/main/v2/requirements.txt).
   In practice, this means that a Python action's *requirements.txt* is ignored.
 * The R runtime is provided by [`r-docker`](https://github.com/opensafely-core/r-docker).
   Its dependencies are in [*packages.csv*](https://github.com/opensafely-core/r-docker/blob/master/packages.csv).

--- a/docs/actions-scripts.md
+++ b/docs/actions-scripts.md
@@ -167,7 +167,12 @@ The `opensafely` command line software should now automatically use this Stata l
 
 ### Python
 
-The Docker image provided is Python 3.8, with [this list of packages installed](https://github.com/opensafely-core/python-docker/blob/main/v1/requirements.txt).
+There are two versions of the Docker image.
+
+* `python:v1`, which for historical reasons is the same as `python:latest`, contains Python 3.8.
+  It has [this list of packages installed](https://github.com/opensafely-core/python-docker/blob/main/v1/requirements.txt).
+* `python:v2` contains Python 3.10.
+  It has [this list of packages installed](https://github.com/opensafely-core/python-docker/blob/main/v2/requirements.txt).
 
 ### R
 

--- a/docs/requesting-libraries.md
+++ b/docs/requesting-libraries.md
@@ -39,7 +39,7 @@ issue](https://github.com/opensafely-core/stata-docker/issues) to request the pa
 
 ## Python packages
 
-First check that the package is not already available, by [viewing all installed packages and their versions for the OpenSAFELY Python image](https://github.com/opensafely-core/python-docker/blob/main/v1/requirements.txt). If your package isn't there then [open an
+First check that the package is not already available, by [viewing all installed packages and their versions for the OpenSAFELY Python image](https://github.com/opensafely-core/python-docker/blob/main/v2/requirements.txt). If your package isn't there then [open an
 issue](https://github.com/opensafely-core/python-docker/issues) to request it be added. Include the following information:
 
 * A link to information about the package;


### PR DESCRIPTION
The broken links in the associated issue aren't broken any more, but point to `python:v1` rather than `python:v2`. As we want to encourage the use of the latter, we link to it instead.

Fixes #1410