### PR TITLE
Use a maintained Slack notify action

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: "Notify Slack on Failure"
         if: ${{ failure() && github.event_name == 'schedule' }}
-        uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # v1.6.0
+        uses: zuplo/github-action-slack-notify-build@cf8e7e66a21d76a8125ea9648979c30920195552 # v2
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:


### PR DESCRIPTION
Fixes #1469.

The `voxmedia` action is deprecated.

We're using the `zuplo` fork elsewhere,
such as in ehrQL:

opensafely-core/ehrql@05992d9db10ced3acb3a227031c8c595f70ce9dd