### PR TITLE
Auto-append the glossary to every page

### DIFF
--- a/docs/actions-pipelines.md
+++ b/docs/actions-pipelines.md
@@ -185,5 +185,3 @@ No data should ever be published from the Level 3 server. Access is only for per
 Highly sensitive outputs can be seen in `E:/high_privacy/workspaces/<WORKSPACE_NAME>`. This includes a directory called `metadata`, containing log files for each action e.g. `generate_dataset.log`, `run_model.log`.
 
 Moderately sensitive outputs can be seen in `E:/FILESFORL4/workspaces/<WORKSPACE_NAME>`.
-
----8<-- 'includes/glossary.md'

--- a/docs/actions-reusable.md
+++ b/docs/actions-reusable.md
@@ -87,5 +87,3 @@ When developing a reusable action, just as when developing a scripted action, th
   Its dependencies are in [*packages.csv*](https://github.com/opensafely-core/r-docker/blob/master/packages.csv).
 * The Stata runtime is provided by [`stata-docker`](https://github.com/opensafely-core/stata-docker).
   Its dependencies are in [*libraries*](https://github.com/opensafely-core/stata-docker/tree/main/libraries).
-
----8<-- 'includes/glossary.md'

--- a/docs/codelist-creation.md
+++ b/docs/codelist-creation.md
@@ -149,7 +149,3 @@ on [our blog](https://www.bennett.ox.ac.uk/blog/2022/11/difference-between-bnf-d
 <div class="video-wrapper">
   <iframe width="1280" height="720" src="https://www.youtube.com/embed/t-A2kWHZ5lA" frameborder="0" allowfullscreen></iframe>
 </div>
-
-
-
----8<-- 'includes/glossary.md'

--- a/docs/codelist-intro.md
+++ b/docs/codelist-intro.md
@@ -44,7 +44,3 @@ any key decisions
 discussion and conversations will be available for examination
 - These discussions should be linked to from the website - i.e. link the issue to the
 final codelist where it appears in OpenSAFELY Codelists
-
-
-
----8<-- 'includes/glossary.md'

--- a/docs/codelist-project.md
+++ b/docs/codelist-project.md
@@ -52,5 +52,3 @@ This command should be re-run every time a codelist is added or removed from the
 If necessary, you can also import CSVs not via OpenCodelists - just manually copy the CSV files into `codelists/`. However, we would recommend uploading these to OpenCodelists to import them as above. Note, if you are _also_ using some codelists from OpenCodelists, any manually imported codelists should be stored in a `local_codelists` folder so that they are not overwritten in the next step, as manual changes to CSV files will be clobbered the next time the command is run.
 
 See more on using Codelists in your study definition in [Working with codelists](legacy/study-def-codelists.md).
-
----8<-- 'includes/glossary.md'

--- a/docs/data-sources/apc.md
+++ b/docs/data-sources/apc.md
@@ -89,6 +89,3 @@ Code | Description
 * [NHS Digital APC data dictionary](https://datadictionary.nhs.uk/data_sets/cds_v6-2/cds_v6-2_type_130_-_admitted_patient_care_-_finished_general_episode_cds.html)
 * [Data resource profile: Hospital Episode Statistics Admitted Patient Care (HES APC)](https://doi.org/10.1093/ije/dyx015)
 * [CLOSER Understanding Hospital Episode Statistics](https://www.closer.ac.uk/wp-content/uploads/CLOSER-resource-understanding-hospital-episode-statistics-2018.pdf)
-
-
----8<-- 'includes/glossary.md'

--- a/docs/data-sources/cpns.md
+++ b/docs/data-sources/cpns.md
@@ -15,7 +15,3 @@ Initially this was lab-confirmed covid deaths only, but also includes suspected 
 * [Press release from Arden&GEM](https://www.ardengemcsu.nhs.uk/showcase/news-events/news-events/supporting-providers-to-record-covid-19-patient-notifications/)
 * [Letter from NHSE to Trust chief execs regarding changes to data collection](https://www.england.nhs.uk/coronavirus/wp-content/uploads/sites/52/2020/04/C0389-update-to-cpns-reporting-letter-27-april-2020.pdf)
 * [Technical summary on data series on deaths in people with COVID-19](https://www.gov.uk/government/publications/phe-data-series-on-deaths-in-people-with-covid-19-technical-summary)
-
-
-
----8<-- 'includes/glossary.md'

--- a/docs/data-sources/ecds.md
+++ b/docs/data-sources/ecds.md
@@ -20,8 +20,3 @@ Diagnoses and discharge destinations are coded using SNOMED CT.
 * [NHS Digital ECDS Information Standard](https://digital.nhs.uk/data-and-information/information-standards/information-standards-and-data-collections-including-extractions/publications-and-notifications/standards-and-collections/dcb0092-2062-commissioning-data-sets-emergency-care-data-set )
 * [NHS Digital ECDS Technical Output Specification](https://digital.nhs.uk/data-and-information/data-collections-and-data-sets/data-sets/emergency-care-data-set-ecds/ecds-latest-update)
 * [ECDS Data Quality Dashboards](https://digital.nhs.uk/data-and-information/data-tools-and-services/data-services/emergency-care-data-set-ecds-data-quality )
-
-
-
-
----8<-- 'includes/glossary.md'

--- a/docs/data-sources/icnarc.md
+++ b/docs/data-sources/icnarc.md
@@ -36,6 +36,3 @@ Specialist units (eg neuro / cardiac) also participate. covid-19 admissions only
 It may be useful to filter by severity, e.g., ventilated patients only.
 Similarly, potentially critically ill patients cared-for by ICU staff but who are admitted to a different unit will not be included in the CMP.
 Each admission is a row, so patients transferred to other units will appear in the dataset multiple times, even if it’s part of the same spell.
-
-
----8<-- 'includes/glossary.md'

--- a/docs/data-sources/intro.md
+++ b/docs/data-sources/intro.md
@@ -12,5 +12,3 @@ GP records, or primary care records, can also be used for conducting health rese
 <div class="video-wrapper">
   <iframe width="1280" height="720" src="https://www.youtube.com/embed/NEwSQ5-dWSg" frameborder="0" allowfullscreen></iframe>
 </div>
-
----8<-- 'includes/glossary.md'

--- a/docs/data-sources/isaric.md
+++ b/docs/data-sources/isaric.md
@@ -4,6 +4,3 @@ The ISARIC dataset contains data from the International Severe Acute Respiratory
 
 !!! warning
     This section is a work in progress.
-
-
----8<-- 'includes/glossary.md'

--- a/docs/data-sources/onsdeaths.md
+++ b/docs/data-sources/onsdeaths.md
@@ -21,6 +21,3 @@ Causes of death are coded using ICD-10.
 ## Glossary
 * **Underlying cause of death (icd10u)** A cause code that identifies the medical condition judged to be the underlying cause of death according to the rules of the _10th Revision of the International Classification of Diseases_. This field appears once for each cause coded routine and inquest death (deaths at age 28 days and over). This code is generally known as 'the cause of death' and is used in single cause tabulations and analyses. The death is assigned the ICD10U code on the basis of ICD-10 codes allocated to the death by the MICAR program. A coder may also manually assign these codes to a death record.
 * **Primary / secondary cause of death** These are not concepts used in ONS cause of death data. There is the underlying cause, and then a list of up to 15 medical conditions (`ICD10001` to `ICD10015`, given as ICD-10 codes) mentioned on the death certificate. These codes are not ordered meaningfully.
-
-
----8<-- 'includes/glossary.md'

--- a/docs/data-sources/systmone.md
+++ b/docs/data-sources/systmone.md
@@ -124,5 +124,3 @@ For those with access to the OpenSAFELY database, the latest database build time
 
 [^1]:
     "Registered" here means a patient with a full "GMS" (General Medical Services) registration. Patients with temporary registrations are not included.
-
----8<-- 'includes/glossary.md'

--- a/docs/data-sources/therapeutics.md
+++ b/docs/data-sources/therapeutics.md
@@ -30,6 +30,3 @@ Treatment dates may be in the past or future at the point when the form is submi
 * **with_these_statuses**: Filters on `CurrentStatus`. Should be one or more of 'Approved', 'Treatment Complete', 'Treatment Not Started', 'Treatment Stopped'.
 Case insensitive.
 * **with_these_indications**: Filters on COVID_indication. Should be one or more of 'non-hospitalised', 'hospital_onset', 'hospitalised_with'.
-
-
----8<-- 'includes/glossary.md'

--- a/docs/data-sources/ukrr.md
+++ b/docs/data-sources/ukrr.md
@@ -1,5 +1,5 @@
-The UK Renal Registry (UKRR) contains data on patients under secondary renal care (advanced chronic kidney disease stages 4 and 5, dialysis, and kidney transplantation). The purpose of the UKRR is to audit secondary kidney 
-care delivery in the UK especially dialysis and kidney transplant. Data is collected from many different renal IT systems. 
+The UK Renal Registry (UKRR) contains data on patients under secondary renal care (advanced chronic kidney disease stages 4 and 5, dialysis, and kidney transplantation). The purpose of the UKRR is to audit secondary kidney
+care delivery in the UK especially dialysis and kidney transplant. Data is collected from many different renal IT systems.
 
 !!! warning
     UKRR data can only be used subject to additional approvals.
@@ -12,5 +12,3 @@ There are 5 different datasets available to OpenSAFELY. These are:
 * **2021_prevalence** *a prevalence cohort of patients alive and on RRT in December 2021*
 * **2020_incidence** *an incidence cohort of patients who started RRT in 2020*
 * **2020_ckd** *a snapshot prevalence cohort of patient with Stage 4 or 5 CKD who were reported to the UKRR to be under renal care in December 2020*
-
----8<-- 'includes/glossary.md'

--- a/docs/five-safes.md
+++ b/docs/five-safes.md
@@ -7,6 +7,3 @@ OpenSAFELY follows the [Five Safes](https://ukdataservice.ac.uk/help/secure-lab/
 * **Safe outputs** - is there any residual risk in outputs being released from the environment?
 
 You can read more about how we use the Five Safes Framework to design the OpenSAFELY platform in our blog post [The ‘Five Safes’ Framework and applying it to OpenSAFELY](https://www.bennett.ox.ac.uk/blog/2023/03/the-five-safes-framework-and-applying-it-to-opensafely/).
-
-
----8<-- 'includes/glossary.md'

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -38,5 +38,3 @@ For a more generic overview, see [GitHub's own guidance](https://guides.github.c
   ![Writing a commit message with GitHub Desktop.](images/getting-started-github-desktop-commit-message.png)
 1. Click **Push origin** to push your local changes to the remote repository on
    GitHub ![Pushing changes to GitHub with GitHub Desktop.](images/getting-started-github-desktop-push-to-github.png)
-
----8<-- 'includes/glossary.md'

--- a/docs/how-to-get-help.md
+++ b/docs/how-to-get-help.md
@@ -88,5 +88,3 @@ please use our [Q&A forum](https://github.com/opensafely/documentation/discussio
 To discuss making your data available to researchers via the OpenSAFELY
 platform, please [contact our technical
 team](mailto:team@opensafely.org).
-
----8<-- 'includes/glossary.md'

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,5 +73,3 @@ See our guidance for [system integrators and data providers](system-integration.
 
 !!! note "These documents are a work-in-progress"
     Please see the [Updating the Documentation page](updating-the-docs.md) if you want to make improvements.
-
----8<-- 'includes/glossary.md'

--- a/docs/install-docker.md
+++ b/docs/install-docker.md
@@ -107,5 +107,3 @@ It is easy to think that it has frozen, but it will take quite a while to get go
   checking Control Panel > Administrative Tools > Services > Server
   was **Disabled**. Setting this to **Automatic** — the default in
   Windows — then started Docker running again.
-
----8<-- 'includes/glossary.md'

--- a/docs/install-python.md
+++ b/docs/install-python.md
@@ -87,6 +87,3 @@ Then enable this version (eg `3.10.1`) in pyenv:
 ```bash
 pyenv global system 3.10.1
 ```
-
-
----8<-- 'includes/glossary.md'

--- a/docs/legacy/study-def-flowcharts.md
+++ b/docs/legacy/study-def-flowcharts.md
@@ -10,6 +10,3 @@ Many studies will require a flowchart to show inclusion/exclusion of patients in
 
  - Make a copy of the study definition (called `study_definition_flow_chart.py`). The `population=patients.satisfying()` function should be replaced with `population=patients.all()`. Then all variables except for those that appeared in the population definition logic should be removed (this will mean that it runs much faster than the main study definition). An example of such a study definition can be seen in [this repository on NSAIDS use and COVID-related outcomes](https://github.com/opensafely/nsaids-covid-research/commit/e5ad58c72926d7c73ba131099486409f6876883d).
  - Then write a script that reads the `input_flow_chart.csv` and then sequentially drops each of the variables and counts the remaining population, in whatever order you'd like to report them; [Stata example](https://github.com/opensafely/nsaids-covid-research/blob/23069312944ea1fc6d79ec4d9b45eea25df96ab0/analysis/flowchart_numbers.do).
-
-
----8<-- 'includes/glossary.md'

--- a/docs/legacy/study-def-measures.md
+++ b/docs/legacy/study-def-measures.md
@@ -221,5 +221,3 @@ To generate the final outputs `measure_hosp_admission_by_stp.csv.gz` and `measur
         measure_csv: output/measures/measure_*.csv.gz
 
 ```
-
----8<-- 'includes/glossary.md'

--- a/docs/legacy/study-def-variables.md
+++ b/docs/legacy/study-def-variables.md
@@ -235,6 +235,3 @@ These variables create new variable from existing variables. They do not extract
 
 ::: cohortextractor.patients.which_exist_in_file
 &nbsp;
-
-
----8<-- 'includes/glossary.md'

--- a/docs/legacy/study-def.md
+++ b/docs/legacy/study-def.md
@@ -343,5 +343,3 @@ actions:
         cohort: output/input-2020-09-01.csv.gz
 ```
 Currently the study definition called above must have the index date defined within the StudyDefinition (e.g. `index_date="2020-01-01"`), though the date defined is arbitrary and is replaced by the arguments defined above.
-
----8<-- 'includes/glossary.md'

--- a/docs/open-data-manifesto.md
+++ b/docs/open-data-manifesto.md
@@ -28,6 +28,3 @@ Operational research is key to understanding what works in the NHS. However the 
 * Use **version control**.
 * Write **tests** for your code.
 * Help develop and follow local **conventions** around coding.
-
-
----8<-- 'includes/glossary.md'

--- a/docs/open-methods.md
+++ b/docs/open-methods.md
@@ -1,14 +1,10 @@
 
-We are using modern open working methods to carry out important analyses whilst preserving patient privacy and keeping all patient data secure. 
+We are using modern open working methods to carry out important analyses whilst preserving patient privacy and keeping all patient data secure.
 
 ## What do we mean by Open Working Methods?
 
-We believe that researchers should be openly sharing all analytic cods and development insights in order to accelerate development of analyses and tools by other groups with other datasets. 
+We believe that researchers should be openly sharing all analytic cods and development insights in order to accelerate development of analyses and tools by other groups with other datasets.
 
-Our tools are build using Python, SQL and Docker. Analyses can be carried out in Python, R or Stata. 
-All our code including analytic code is shared on GitHub and is open access for efficiency, reuse and collaboration. 
-We encourage external review and reuse of our code. 
-
-
-
----8<-- 'includes/glossary.md'
+Our tools are build using Python, SQL and Docker. Analyses can be carried out in Python, R or Stata.
+All our code including analytic code is shared on GitHub and is open access for efficiency, reuse and collaboration.
+We encourage external review and reuse of our code.

--- a/docs/output-checking.md
+++ b/docs/output-checking.md
@@ -22,6 +22,3 @@ Below are the most common problems encountered by output checkers when reviewing
 5. **Unsupported file types being requested**. Files requested for release should be one of the [allowed file types](requesting-file-release.md#allowed-file-types). If you are requesting the release of HTML files, please make sure you have followed the [guidance for HTML files](requesting-file-release.md#allowed-file-types). **~10%** of rejected outputs are due to unsupported file types being requested.
 
 To help avoid these issues, please make sure you have read the [checklist](requesting-file-release.md#checklist) before submitting your review request.
-
-
----8<-- 'includes/glossary.md'

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -8,5 +8,3 @@ Briefly, pre-specifying your research question and developing a study protocol w
 Taken together, this can improve both the quality and credibility of your research. Developing a detailed study plan, including figure and table shells, can be particularly helpful when using a federated analytics platform such as OpenSAFELY, as there is less scope for interactively developing these whilst working with the data.
 
 This page will eventually contain resources for how to develop an effective study protocol, as well as tips for how to pre-register these formally on [OSF](https://osf.io/) or [ENCePP](http://www.encepp.eu/), or informally by uploading "locked" protocol versions to GitHub. There is no specific template for a protocol that you should use when working with OpenSAFELY, but you can see examples of protocols we've written for OpenSAFELY studies on most of our public repositories — for example [this inhaled corticosteroid (ICS) research repository](https://github.com/opensafely/ics-research/tree/master/protocol) or [this ethnicity research repository](https://github.com/opensafely/ethnicity-covid-research/tree/master/protocol).
-
----8<-- 'includes/glossary.md'

--- a/docs/releasing-files-intro.md
+++ b/docs/releasing-files-intro.md
@@ -8,6 +8,3 @@ In OpenSAFELY, there are 4 key “Safe Outputs” activities:
 2.  [Requesting release of outputs from the Level 4 server](requesting-file-release.md) that are necessary to fulfil the purpose of a project.
 3.  [Review of the requested outputs](output-checking.md) by two trained OpenSAFELY output checkers.
 4.  [Release of outputs that meet our disclosure rules](releasing-files.md) to the relevant workspace on the [Jobs site](jobs-site.md).
-
-
----8<-- 'includes/glossary.md'

--- a/docs/releasing-files.md
+++ b/docs/releasing-files.md
@@ -17,6 +17,3 @@ If you have had [intermediate data released](requesting-file-release.md#release-
 ### Reporting a data breach
 
 If you discover files released to the Jobs site that have been insufficiently redacted and still contain sensitive information, you should immediately contact and email the following (providing as much information as possible): Amir Mehrkar (<amir.mehrkar@phc.ox.ac.uk>); Ben Goldacre (<ben.goldacre@phc.ox.ac.uk>); [disclosurecontrol@opensafely.org](mailto:disclosurecontrol@opensafely.org); and your co-pilot. Ensure you do not share these files and if they have already been shared please identify as best as possible with whom they have been shared.
-
-
----8<-- 'includes/glossary.md'

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -129,7 +129,3 @@ If you want to create an empty folder to save files in, but you _never_ want its
 ```
 
 This can be useful if you want to, for example, add a `output/plots/` subfolder to put your analysis plots into without having to check and create that folder explicitly every time in the analysis script.  This is necessary because the contents of the `output/` folder is ignored by the default `.gitignore` in the root (the top-level) of the repository.
-
-
-
----8<-- 'includes/glossary.md'

--- a/docs/requesting-file-release.md
+++ b/docs/requesting-file-release.md
@@ -110,6 +110,3 @@ Once you have completed this form, please send it to **<datarelease@opensafely.o
     Our resources for checking outputs are not unlimited, therefore it is advised to ensure you have all of your outputs ready at the same time for your project (or its current phase) so they can be reviewed together. Please make your outputs as understandable as possible for output checkers who will not be familiar with your project by, for example, using descriptive variable names and providing full descriptions of each output in the form provided.
 
     Another reason to ensure your analyses are complete is that re-running your study definition a short time later (e.g. to create an additional variable) may produce small differences in the previous results, e.g. due to movement of patients or codes added retrospectively to patient records. If you have already released similar results, any small changes in new outputs may be subject to small number suppression which may prevent the new outputs being released at all. (One solution to minimise this issue is to round all of your results, e.g. to the nearest 5).
-
-
----8<-- 'includes/glossary.md'

--- a/docs/requesting-libraries.md
+++ b/docs/requesting-libraries.md
@@ -53,7 +53,3 @@ This will only be feasible if the functions do not have a complex hierarchy of d
 For instance, in many cases, Stata packages can be added by copying the relevant `ado` files into the project repo.
 
 Either way, you should make an issue for the package so that other users are aware of the package's history in OpenSAFELY.
-
-
-
----8<-- 'includes/glossary.md'

--- a/docs/sdc.md
+++ b/docs/sdc.md
@@ -186,6 +186,3 @@ There are also resources for extended guidance for analysis methods commonly use
     [O’Keefe, C. M., Sparks, R. S., McAullay, D. & Loong, B. Confidentialising Survival Analysis Output in a Remote Data Access System. J. Priv. Confidentiality 4, (2012)](https://journalprivacyconfidentiality.org/index.php/jpc/article/view/614)
 
 There is also a disclosure control section in our [Q&A forum](https://github.com/opensafely/documentation/discussions/categories/disclosure-control) where you can ask any questions you may have.
-
-
----8<-- 'includes/glossary.md'

--- a/docs/security-levels.md
+++ b/docs/security-levels.md
@@ -79,5 +79,3 @@ Any level 4 files that have been cleared by output-checkers, and therefore consi
 ## Diagram
 
 ![A diagram of the OpenSAFELY platform.](./images/NON-COVID-GP-data-OpenSAFELY-platform-architecture-and-dataflows-V5-for-DPIA-DPN.drawio.svg)
-
----8<-- 'includes/glossary.md'

--- a/docs/system-integration.md
+++ b/docs/system-integration.md
@@ -69,5 +69,3 @@ that you can refer to.
 
 See our [support page](how-to-get-help.md#data-providers)
 for details of how to get more assistance on integration.
-
----8<-- 'includes/glossary.md'

--- a/docs/updating-the-docs.md
+++ b/docs/updating-the-docs.md
@@ -34,6 +34,3 @@ updated to match the new incremented version of `cohortextractor`. See
 the [documentation repository's
 README](https://github.com/opensafely/documentation#building-locally-and-testing)
 that details the use of `pip-compile` for this.
-
-
----8<-- 'includes/glossary.md'

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -30,6 +30,3 @@ This pipeline is also [automatically tested](actions-pipelines.md#running-your-c
 
 As well as your own Python, R or Stata scripts, other non-standard actions are available.
 For example, it's possible to run a matching routine that extracts a matched control population to the population defined in the study definition, without having to extract all candidate matches into a dataset first.
-
-
----8<-- 'includes/glossary.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -192,6 +192,8 @@ markdown_extensions:
       base_path: # base paths will be checked in order for matching snippets
         - .  # dir containing this config file
         - imported_docs/ehrql # docs folder for the imported repo
+      auto_append:
+        - includes/glossary.md
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid


### PR DESCRIPTION
Use the `auto_append` option for snippets so we don't need to include the glossary on every page.

This also means that the main docs glossary will be auto-appended to the imported Airlock docs (along with Airlock's own glossary).