### PR TITLE
Fix links

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -19,6 +19,7 @@ https?://www\.encepp\.eu(?:/.*)?$
 https?://www\.tandfonline\.com(?:/.*)?$
 https?://www\.icnarc\.org(?:/.*)?$
 https?://doi\.org(?:/.*)?$
+https?://digital.nhs.uk(?:/.*$)?$
 
 # Twitter used to work but is being very flaky.
 # This exclusion should be reviewed in future to see if the issue persists.

--- a/docs/codelist-updating.md
+++ b/docs/codelist-updating.md
@@ -16,7 +16,7 @@ run do not need to update codelists in order to run successfully.
 !!! Info
 
     [The Dictionary of Medicines and Devices (dm+d)](https://www.bennett.ox.ac.uk/blog/2019/08/what-is-the-dm-d-the-nhs-dictionary-of-medicines-and-devices/)[^1]
-    is a dictionary of descriptions and (SNOMED-CT) codes which represent medicines and devices in use across the NHS. The codes representing specific medicines can change, and [require special treatment](#dmd-a-special-case), described below. As a result,
+    is a dictionary of descriptions and (SNOMED-CT) codes which represent medicines and devices in use across the NHS. The codes representing specific medicines can change, and [require special treatment](#addressing-changing-dmd-codes), described below. As a result,
     dm+d codelists now download with standardised column headings: "code" (the dm+d code), and "term" (the description) in the CSV files. For backwards compatibility, they also
     include a column with the original code column heading (typically "dmd_id") [^2].
 

--- a/docs/data-access-policy.md
+++ b/docs/data-access-policy.md
@@ -113,7 +113,7 @@ While co-piloting activities are largely focused on the first four weeks of trai
 ### Why
 
 A key element of the OpenSAFELY service, and one of the [Five Safes](https://www.bennett.ox.ac.uk/blog/2023/03/the-five-safes-framework-and-applying-it-to-opensafely/) is “safe outputs”.
-Statistical disclosure control is applied as necessary to research outputs, which then go through an [output checking process](../outputs/index.md) to minimise the risk of disclosure of identifiable information before outputs are released from the secure environment.
+Statistical disclosure control is applied as necessary to research outputs, which then go through an [output checking process](outputs/index.md) to minimise the risk of disclosure of identifiable information before outputs are released from the secure environment.
 
 ### What
 

--- a/docs/getting-started/how-to/troubleshoot-common-codespaces-issues/index.md
+++ b/docs/getting-started/how-to/troubleshoot-common-codespaces-issues/index.md
@@ -86,5 +86,4 @@ If you have actions defined in your [project pipeline file](../../../actions-pip
 If this is the case for your project, your options are:
 
 * Update your project pipeline file to reference the most recent action images and make any neccesary changes to your code
-* Retain the references to the older action images, and use [`opensafely exec`](../../../opensafely-cli.md#exec---interactive-development) for interactive development using these action images' environments
-
+* Retain the references to the older action images, and use [`opensafely exec`](../../../opensafely-cli.md#exec-interactive-development) for interactive development using these action images' environments

--- a/docs/updating-the-docs.md
+++ b/docs/updating-the-docs.md
@@ -3,7 +3,7 @@ If you are an OpenSAFELY user and want to contribute corrections, clarifications
 You can either:
 
 * Suggest improvements in an [issue](https://github.com/opensafely/documentation/issues).
-* Run the documentation [in GitHub Codespaces](#running-in-codespaces) for editing.
+* Run the documentation [in GitHub Codespaces](#running-in-github-codespaces) for editing.
 * Clone [the repo](https://github.com/opensafely/documentation) locally, make edits on a new branch, then create a pull request for it.
 * [Edit directly on GitHub](https://github.com/opensafely/documentation/tree/main/docs) ([instructions](https://docs.github.com/en/github/managing-files-in-a-repository/editing-files-in-your-repository)), making sure to "Create a new branch for this commit and start a pull request".
 


### PR DESCRIPTION
1) Fix some actually broken links and anchors. 
2) All digital.nhs.uk links are returning 403s now in the [links check](https://github.com/opensafely/documentation/actions/runs/10791686722), despite working before.  This seems to be a persistent failure (at least, it's been consistent for the last 24 hrs or so) I've verified that all the links are accessible in a browser, so have just added them to the ignore list.