### PR TITLE
Update `project.yaml` examples to pipeline v4 if the example only has ehrQL actions

### DIFF
--- a/docs/actions-pipelines.md
+++ b/docs/actions-pipelines.md
@@ -28,11 +28,7 @@ It is written using a configuration format called [YAML](https://yaml.org/), whi
 A simple example of a `project.yaml` is as follows:
 
 ```yaml
-version: "3.0"
-
-# Ignore this `expectations` block. It is required but not used, and will be removed in future versions.
-expectations:
-  population_size: 1000
+version: "4.0"
 
 actions:
   generate_dataset:
@@ -60,7 +56,7 @@ The `run_model` action will run a Stata script called `model.do` based on the `d
 It will output two moderately sensitive files `cox-model.txt` and `survival-plot.png`, which can be checked and released if appropriate.
 
 
-Every `project.yaml` requires a `version`, `expectations`, and `actions` section.
+Every `project.yaml` requires a `version` and `actions` section. An `expectations` section was also required for version 3.0 of the pipeline framework (example [here](case-control-studies.md)), but is not used in the latest version.
 In general, actions are composed as follows:
 
 * Each action must be named using a valid YAML key (you won't go wrong with letters, numbers, and underscores) and must be unique.

--- a/docs/getting-started/tutorial/add-a-scripted-action-to-the-pipeline/index.md
+++ b/docs/getting-started/tutorial/add-a-scripted-action-to-the-pipeline/index.md
@@ -67,11 +67,7 @@ This code reads the CSV of patient data, and saves a histogram of ages to a new 
 === "Python"
 
     ```yaml linenums="1" hl_lines="14 15 16 17 18 19"
-    version: "3.0"
-
-    # Ignore this `expectations` block. It is required but not used, and will be removed in future versions.
-    expectations:
-      population_size: 1000
+    version: "4.0"
 
     actions:
       generate_dataset:
@@ -91,11 +87,7 @@ This code reads the CSV of patient data, and saves a histogram of ages to a new 
 === "R"
 
     ```yaml linenums="1" hl_lines="14 15 16 17 18 19"
-    version: "3.0"
-
-    # Ignore this`expectation` block. It is required but not used, and will be removed in future versions.
-    expectations:
-      population_size: 1000
+    version: "4.0"
 
     actions:
       generate_dataset:

--- a/docs/getting-started/tutorial/run-the-project-pipeline/index.md
+++ b/docs/getting-started/tutorial/run-the-project-pipeline/index.md
@@ -24,11 +24,7 @@ open the `project.yaml` file by clicking on it. This file will be near the end o
 You should see a tab with the following content:
 
 ```yaml linenums="1" hl_lines="9"
-version: "3.0"
-
-# Ignore this `expectations` block. It is required but not used, and will be removed in future versions.
-expectations:
-  population_size: 1000
+version: "4.0"
 
 actions:
   generate_dataset:


### PR DESCRIPTION
- Part of [upgrading pipeline to version 4](https://github.com/orgs/opensafely-core/projects/15/views/1?pane=issue&itemId=81337702&issue=opensafely-core%7Cpipeline%7C224)
- Version 4 of pipeline removes support for cohort extractor and the `project.yaml` file should not have an `expectations` section.
- `case-control-studies.md` has examples that use cohort extractor actions so nothing has been changed there. Is there a reason why this page wasn't updated to use ehrQL? 