### PR TITLE
Ignore some errors when checking links

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -42,5 +42,7 @@ jobs:
       - name: Check links
         uses: lycheeverse/lychee-action@7cd0af4c74a61395d455af97419279d86aafaede  # v2.0.2
         with:
-          args: "--exclude-all-private --include-verbatim --max-concurrency 24 --require-https --verbose --no-progress --timeout 60 './docs/**/*.md' './docs/**/*.html' './imported_docs/**/*.md' './imported_docs/**/*.html' --exclude-path './docs/ehrql/includes/generated_docs'"
+          args: "--exclude-all-private --include-verbatim --max-concurrency 24 --require-https --verbose --no-progress
+          --accept '100..=103,200..=299,429,500..=511'
+          --timeout 60 './docs/**/*.md' './docs/**/*.html' './imported_docs/**/*.md' './imported_docs/**/*.html' --exclude-path './docs/ehrql/includes/generated_docs'"
           token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
We are currently seeing the link checking workflow fail on transient errors. So we should tell lychee to accept a wider range of responses, such as server errors and timeouts, as these don't indicate a broken link, but are instead temporary issues that we don't need to act upon.

I've made a "successful" [run](https://github.com/opensafely/documentation/actions/runs/11821198838) to demonstrate that the change has worked. It's failed on a 40x status code, but that's expected behaviour. 