### PR TITLE
Tweak Codespace retention warning

### DIFF
--- a/docs/getting-started/how-to/add-github-codespaces-to-your-project/index.md
+++ b/docs/getting-started/how-to/add-github-codespaces-to-your-project/index.md
@@ -1,7 +1,7 @@
 This page describes how to add GitHub Codespaces to your project.
 
 !!! warning
-    Codespaces are automatically deleted after a period of inactivity and any changes not pushed to the GitHub repo will be lost.
+    By default, Codespaces are automatically deleted after a period of inactivity and any changes not pushed to the GitHub repo will be lost.
     For the `opensafely` organization,
     this period is 30 days.
 

--- a/docs/getting-started/how-to/use-github-codespaces-in-your-project/index.md
+++ b/docs/getting-started/how-to/use-github-codespaces-in-your-project/index.md
@@ -1,7 +1,7 @@
 This page explains how to work with OpenSAFELY projects using GitHub Codespaces.
 
 !!! warning
-    Codespaces are automatically deleted after a period of inactivity and any changes not pushed to the GitHub repo will be lost.
+    By default, Codespaces are automatically deleted after a period of inactivity and any changes not pushed to the GitHub repo will be lost.
     For the `opensafely` organization,
     this period is 30 days.
 


### PR DESCRIPTION
We've removed the explicit policy that enforces the 30 day limit, which means that people can opt-out of auto-deletion on a per-Codespace basis. I don't expect this to happen very often and I don't think a warning box is the right place to explain how to do it, so I've avoided going into any detail here.

Refs: https://github.com/opensafely-core/research-template-docker/issues/78