### PR TITLE
Set up Plausible script as custom site analytics

### DIFF
--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -1,15 +1,3 @@
-const domain = "docs.opensafely.org";
-
-if (document.location.hostname === domain) {
-  const script = document.createElement("script");
-  script.defer = true;
-  script.setAttribute("data-domain", domain);
-  script.id = "plausible";
-  script.src = "https://plausible.io/js/plausible.compat.js";
-
-  document.head.appendChild(script);
-}
-
 function getTextWithoutPromptAndOutput(targetSelector) {
   const targetElement = document.querySelector(targetSelector);
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,8 @@ extra_javascript:
   - js/lite-yt-embed.js
 
 extra:
+  analytics:
+    provider: plausible
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/opensafely

--- a/overrides/partials/integrations/analytics/plausible.html
+++ b/overrides/partials/integrations/analytics/plausible.html
@@ -1,0 +1,1 @@
+<script defer data-domain="docs.opensafely.org" src="https://plausible.io/js/script.js"></script>


### PR DESCRIPTION
Linked to https://github.com/opensafely-core/sysadmin/issues/175

As [referenced in the Material for Mkdocs documentation](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#custom-site-analytics), this applies Plausible script as Custom Site Analytics.