### PR TITLE
Fix broken links for r:v1 package data

### DIFF
--- a/docs/actions-reusable.md
+++ b/docs/actions-reusable.md
@@ -84,6 +84,6 @@ When developing a reusable action, just as when developing a scripted action, th
   Its dependencies are in [*requirements.txt*](https://github.com/opensafely-core/python-docker/blob/main/v2/packages.md).
   In practice, this means that a Python action's *requirements.txt* is ignored.
 * The R runtime is provided by [`r-docker`](https://github.com/opensafely-core/r-docker).
-  Its dependencies are in [*packages.csv*](https://github.com/opensafely-core/r-docker/blob/master/packages.csv).
+  Its dependencies are in [*packages.md*](https://github.com/opensafely-core/r-docker/blob/main/v1/packages.md).
 * The Stata runtime is provided by [`stata-docker`](https://github.com/opensafely-core/stata-docker).
   Its dependencies are in [*libraries*](https://github.com/opensafely-core/stata-docker/tree/main/libraries).

--- a/docs/actions-scripts.md
+++ b/docs/actions-scripts.md
@@ -187,4 +187,4 @@ There are two versions of the Docker image.
 
 ### R
 
-The R image provided is R 4.0, with [this list of libraries installed](https://github.com/opensafely-core/r-docker/blob/master/packages.csv).
+The R image provided is R 4.0, with [this list of libraries installed](https://github.com/opensafely-core/r-docker/blob/main/v1/packages.md).

--- a/docs/requesting-libraries.md
+++ b/docs/requesting-libraries.md
@@ -9,7 +9,7 @@ and let [tech-support](/how-to-get-help#slack) know.
 ## R packages
 
 First check that the package is not already available, by [viewing all installed packages and their versions for the
-OpenSAFELY R image](https://github.com/opensafely-core/r-docker/blob/master/packages.csv). If your package isn't there then [open an
+OpenSAFELY R image](https://github.com/opensafely-core/r-docker/blob/main/v1/packages.md)). If your package isn't there then [open an
 issue](https://github.com/opensafely-core/r-docker/issues) to request it be added. Include the following information:
 
 * A link to the CRAN page for the package;


### PR DESCRIPTION
In preparing for v2: we changed this, and the links broke.

Also worth noting that those are md links now, not csv, like pythons
package version info, and are better formatter, with links.
