### PR TITLE
Move footer buttons to content area

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -174,3 +174,26 @@ body {
 .md-sidebar {
   padding: 0;
 }
+
+.footer-nav-buttons {
+  border-top: 1px solid var(--colorLightGrey);
+
+  .md-footer__link {
+    color: var(--colorLink);
+    font-weight: 600;
+    text-decoration-color: var(--colorLinkHeader);
+    text-underline-offset: 2px;
+
+    .md-footer__title {
+      font-size: 0.8rem;
+    }
+
+    .md-footer__direction {
+      opacity: 0.9;
+    }
+
+    .md-ellipsis {
+      text-decoration: underline;
+    }
+  }
+}

--- a/docs/getting-started/tutorial/add-a-scripted-action-to-the-pipeline/index.md
+++ b/docs/getting-started/tutorial/add-a-scripted-action-to-the-pipeline/index.md
@@ -125,8 +125,3 @@ or right-click on `report.png` and select Download to download the image.
     Changes you make to files are automatically saved on GitHub. However, changes will not persist
     outside of the GitHub codespace unless you *commit* and *push* them to GitHub, as described
     in the next section.
-
----
-
-* Previous: [Run the project pipeline](../run-the-project-pipeline/index.md)
-* Next: [Publish the changes to GitHub](../publish-the-changes-to-github/index.md)

--- a/docs/getting-started/tutorial/check-the-automated-tests-pass/index.md
+++ b/docs/getting-started/tutorial/check-the-automated-tests-pass/index.md
@@ -12,8 +12,3 @@ commit. The workflow verifies that the command `opensafely run run_all` can
 run successfully. If it's yellow, it's still running. If it's red, it
 has failed. If it's green, it has succeeded. You want it to be green!
 ![The GitHub Actions tab showing a successful workflow.](../../../images/getting-started-github-actions-workflow-success.png)
-
----
-
-* Previous: [Publish the changes to GitHub](../publish-the-changes-to-github/index.md)
-* Next: [Delete the GitHub codespace](../delete-the-github-codespace/index.md)

--- a/docs/getting-started/tutorial/create-a-github-account/index.md
+++ b/docs/getting-started/tutorial/create-a-github-account/index.md
@@ -23,8 +23,3 @@ to visit to confirm your account.
 
 We recommend that you [secure your GitHub account with two-factor
 authentication](https://docs.github.com/en/github/authenticating-to-github/securing-your-account-with-two-factor-authentication-2fa).
-
----
-
-* Previous: [Introduction](../introduction/index.md)
-* Next: [Create a GitHub repository](../create-a-github-repository/index.md)

--- a/docs/getting-started/tutorial/create-a-github-codespace/index.md
+++ b/docs/getting-started/tutorial/create-a-github-codespace/index.md
@@ -69,8 +69,3 @@ available commands:
     pull      Command for updating the docker images used to run OpenSAFELY studies locally
     upgrade   Upgrade the opensafely cli tool.
 ```
-
----
-
-* Previous: [Create a GitHub repository](../create-a-github-repository/index.md)
-* Next: [Generate a first dataset](../generate-a-first-dataset/index.md)

--- a/docs/getting-started/tutorial/create-a-github-repository/index.md
+++ b/docs/getting-started/tutorial/create-a-github-repository/index.md
@@ -17,8 +17,3 @@ account and use it to develop your own study:
    repository.
 
    If you see `${GITHUB_REPOSITORY_NAME}` in your README, the repo is not yet initialised; wait a few seconds longer and reload.
-
----
-
-* Previous: [Create a GitHub account](../create-a-github-account/index.md)
-* Next: [Create a GitHub codespace](../create-a-github-codespace/index.md)

--- a/docs/getting-started/tutorial/delete-the-github-codespace/index.md
+++ b/docs/getting-started/tutorial/delete-the-github-codespace/index.md
@@ -3,8 +3,3 @@
 If you close a Codespace in your browser, it still continues running. So, once you've finished using your Codespace, you can delete it.
 
 There's information about how to do this on our [Codespaces](../../how-to/use-github-codespaces-in-your-project/index.md#how-to-delete-a-codespace) page.
-
----
-
-* Previous: [Check the automated tests pass](../check-the-automated-tests-pass/index.md)
-* Next: [See the next steps](../see-the-next-steps/index.md)

--- a/docs/getting-started/tutorial/generate-a-first-dataset/index.md
+++ b/docs/getting-started/tutorial/generate-a-first-dataset/index.md
@@ -44,8 +44,3 @@ Notice the columns: `patient_id` and `sex`.
 
 In the next part of the tutorial,
 we will see how to add another data column.
-
----
-
-* Previous: [Create a GitHub codespace](../create-a-github-codespace/index.md)
-* Next: [Update the dataset definition](../update-the-dataset-definition/index.md)

--- a/docs/getting-started/tutorial/publish-the-changes-to-github/index.md
+++ b/docs/getting-started/tutorial/publish-the-changes-to-github/index.md
@@ -77,8 +77,3 @@ The repository was created at:
 If you now visit the repository on the main GitHub site,
 you should see the updated state of the repository
 with the changes you made in the codespace.
-
----
-
-* Previous: [Add a scripted action to the pipeline](../add-a-scripted-action-to-the-pipeline/index.md)
-* Next: [Check the automated tests pass](../check-the-automated-tests-pass/index.md)

--- a/docs/getting-started/tutorial/run-the-project-pipeline/index.md
+++ b/docs/getting-started/tutorial/run-the-project-pipeline/index.md
@@ -111,8 +111,3 @@ The difference between them is that:
 * `opensafely run` runs actions *inside* the project pipeline -
   that is, just as they would be in the secure OpenSAFELY environment
   containing real patient data
-
----
-
-* Previous: [Update the dataset definition](../update-the-dataset-definition/index.md)
-* Next: [Add a scripted action to the pipeline](../add-a-scripted-action-to-the-pipeline/index.md)

--- a/docs/getting-started/tutorial/see-the-next-steps/index.md
+++ b/docs/getting-started/tutorial/see-the-next-steps/index.md
@@ -26,7 +26,3 @@ We also recommend:
 
 * [OpenSAFELY Jobs](https://jobs.opensafely.org)
 * [the Visual Studio Code introduction to Git](https://code.visualstudio.com/docs/sourcecontrol/intro-to-git)
-
----
-
-* Previous: [Delete the GitHub codespace](../delete-the-github-codespace/index.md)

--- a/docs/getting-started/tutorial/update-the-dataset-definition/index.md
+++ b/docs/getting-started/tutorial/update-the-dataset-definition/index.md
@@ -39,8 +39,3 @@ to the age of each patient on the given date*".
    ```
 
    and press ++enter++, you will see a new randomly generated dataset which now contains the additional `age` column.
-
----
-
-* Previous: [Generate a first dataset](../generate-a-first-dataset/index.md)
-* Next: [Run the project pipeline](../run-the-project-pipeline/index.md)

--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -37,3 +37,30 @@ function patchCopyCodeButtons() {
 document.addEventListener("DOMContentLoaded", () => {
   patchCopyCodeButtons();
 });
+
+/**
+ * Move the existing footer buttons to the main content section
+ * @returns {void}
+ */
+function moveNavButtons() {
+  /** @type {HTMLDivElement} */
+  const contentArea = document.querySelector(`[data-md-component="content"]`);
+  /** @type {HTMLElement} */
+  const footerNav = document.querySelector(`[aria-label="Footer"]`);
+  /** @type {HTMLElement} */
+  const footClone = footerNav.cloneNode(true);
+  footClone.classList.add("footer-nav-buttons");
+  contentArea.appendChild(footClone);
+  footerNav.setAttribute("hidden", "true");
+}
+
+/** @type {string[]} */
+const buttonPaths = ["/getting-started/tutorial/", "/ehrql/tutorial/"];
+/** @type {string} */
+const docPath = window.location.pathname;
+
+for (const path of buttonPaths) {
+  if (docPath.startsWith(path)) {
+    moveNavButtons();
+  }
+}

--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -56,7 +56,15 @@ function moveNavButtons() {
 }
 
 /** @type {string[]} */
-const buttonPaths = ["/getting-started/tutorial/", "/ehrql/tutorial/"];
+const buttonPaths = [
+  "/ehrql/tutorial/",
+  "/getting-started/tutorial/",
+  "/outputs/output-checking/",
+  "/outputs/releasing-overview/",
+  "/outputs/requesting-file-release/",
+  "/outputs/sdc/",
+  "/outputs/viewing-released-files/",
+];
 /** @type {string} */
 const docPath = window.location.pathname;
 

--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -39,7 +39,8 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 /**
- * Move the existing footer buttons to the main content section
+ * Move the existing footer buttons to the main content section to make them more visible.
+ * Material MKDocs doesn’t seem to have any options to do this natively.
  * @returns {void}
  */
 function moveNavButtons() {


### PR DESCRIPTION
Closes #1513

URLs starting with the path names listed in the [`buttonPaths` array of `extra.js`](https://github.com/opensafely/documentation/pull/1724/files#diff-471feeb498f79e7b563705cc384c369e28a28bde530c4734bc604fbced7a7a11R58) have buttons moved from the footer, to the main content area.

## Before

![02](https://github.com/user-attachments/assets/c5908aaf-3488-476b-b979-a44f38676ab9)
![04](https://github.com/user-attachments/assets/be9aae09-0cbf-4d71-9bef-e48703579df5)

## After

![03](https://github.com/user-attachments/assets/c8c44df5-4711-4222-adfd-950855653a05)
![01](https://github.com/user-attachments/assets/d7034f94-6a2e-4cdf-8958-b761f9e8e682)
