### PR TITLE
Update OpenSafely tutorial documentation

### DIFF
--- a/docs/getting-started/tutorial/add-a-scripted-action-to-the-pipeline/index.md
+++ b/docs/getting-started/tutorial/add-a-scripted-action-to-the-pipeline/index.md
@@ -66,7 +66,7 @@ This code reads the CSV of patient data, and saves a histogram of ages to a new 
 
 === "Python"
 
-    ```yaml linenums="1" hl_lines="14 15 16 17 18 19"
+    ```yaml linenums="1" hl_lines="10 11 12 13 14 15"
     version: "4.0"
 
     actions:
@@ -86,7 +86,7 @@ This code reads the CSV of patient data, and saves a histogram of ages to a new 
 
 === "R"
 
-    ```yaml linenums="1" hl_lines="14 15 16 17 18 19"
+    ```yaml linenums="1" hl_lines="10 11 12 13 14 15"
     version: "4.0"
 
     actions:
@@ -104,24 +104,28 @@ This code reads the CSV of patient data, and saves a histogram of ages to a new 
             chart: output/report.png
     ```
 
-- **Line 14** tells the system we want to create a new action called `generate_report`.
-- **Line 15** says how to run the script (using the `python` or `R` runner).
-- **Line 16** tells the system that this action depends on the outputs of the
+- **Line 10** tells the system we want to create a new action called `generate_report`.
+- **Line 11** says how to run the script (using the `python` or `R` runner).
+- **Line 12** tells the system that this action depends on the outputs of the
   `generate_dataset` being present.
-- **Lines 17-19** describe the files that the action creates. Line 18 says that the
+- **Lines 13-15** describe the files that the action creates. Line 14 says that the
   items indented below it are *moderately* sensitive, which means they may be released
-  to the public after a careful review (and possible redaction). Line 19 says that
+  to the public after a careful review (and possible redaction). Line 15 says that
   there's one output file, which will be found at `output/report.png`.
 
+   In the Visual Studio Code Terminal, type:
 
-At the command line, type `opensafely run generate_report` and press
-++enter++. This should end by telling you a file containing the histogram has been created.
+   ```
+   opensafely run generate_report
+   ```
+and press ++enter++. This should end by telling you a file containing the histogram has been created.
 Open the `output` folder — you can do this via Visual Studio Code's Explorer — and check that it contains `report.png`.
 
 Double click on `report.png` to display the image,
 or right-click on `report.png` and select Download to download the image.
 
 !!! warning
-    Changes you make to files are automatically saved on GitHub. However, changes will not persist
-    outside of the GitHub codespace unless you *commit* and *push* them to GitHub, as described
-    in the next section.
+    Changes will not persist outside of the GitHub codespace
+    unless you *commit* and *push* them to GitHub, as described in the
+    next section.
+

--- a/docs/getting-started/tutorial/check-the-automated-tests-pass/index.md
+++ b/docs/getting-started/tutorial/check-the-automated-tests-pass/index.md
@@ -8,7 +8,7 @@ Visit your repository on GitHub's site. Click on the **Actions** tab
 ![The GitHub Actions tab in a repository.](../../../images/getting-started-github-actions-tab.png)
 
 You'll see a *Workflow* running with the *commit message* of your last
-commit. The workflow verifies that the command `opensafely run run_all` can
-run successfully. If it's yellow, it's still running. If it's red, it
-has failed. If it's green, it has succeeded. You want it to be green!
+commit. The workflow verifies that all of the actions in your project pipeline can run.
+
+If the action icon is green (as shown below), it's succeeded. If it's yellow, it's still running. If it's red, it has failed. You want it to be green!
 ![The GitHub Actions tab showing a successful workflow.](../../../images/getting-started-github-actions-workflow-success.png)

--- a/docs/getting-started/tutorial/delete-the-github-codespace/index.md
+++ b/docs/getting-started/tutorial/delete-the-github-codespace/index.md
@@ -1,5 +1,13 @@
 ## Tidy up
 
-If you close a Codespace in your browser, it still continues running. So, once you've finished using your Codespace, you can delete it.
+If you close a codespace in your browser, it still continues running. So, once you've finished using your codespace, you can delete it.
 
-There's information about how to do this on our [Codespaces](../../how-to/use-github-codespaces-in-your-project/index.md#how-to-delete-a-codespace) page.
+There's more information about how to delete your codespace, and why you should delete any codespaces you no longer need, in [GitHub's documentation on deleting a codespace](https://docs.github.com/en/codespaces/developing-in-a-codespace/deleting-a-codespace).
+
+It's important to note that saving files in your codespace only ensures that changes persist in that codespace's storage. So, when you delete your codespace, any changes will be lost unless they are pushed to the remote repository that GitHub hosts.
+
+!!! warning
+    By default, codespaces are automatically deleted after a period of inactivity and any changes not pushed to the remote GitHub repository will be lost.
+    For the `opensafely` organization,
+    this period is 30 days.
+

--- a/docs/getting-started/tutorial/publish-the-changes-to-github/index.md
+++ b/docs/getting-started/tutorial/publish-the-changes-to-github/index.md
@@ -2,20 +2,20 @@ So far,
 the changes you have made only exist in the codespace in which you are working.
 
 In this section, you will first add the study changes that you've made
-to a new *commit* in your repository — a commit represents a stored
-version of your work — and then send that commit to GitHub by *pushing*
+to a new *commit* in your local repository — a commit represents a stored
+version of your work — and then send that commit to the remote repository that GitHub hosts by *pushing*
 the new commit.
 
-Pushing changes to your GitHub repository:
+Pushing changes to your remote GitHub repository:
 
 * ensures the changes you have made persist even when the codespace is deleted
 * enables others with permission to access your repository to see those changes
 
 ## Add your changes to the local repository
 
-(If you know how to use command-line Git, this works within
-GitHub's terminal if you do not want to use Visual Studio Code's
-Source Control feature.)
+If you know how to use Git with the command-line, you can do
+so in the Visual Studio Code Terminal. Alternatively, you can use Visual
+Studio Code's Source Control feature, as demonstrated below.
 
 Back in the GitHub codespace, open the Source Control panel by
 selecting the icon that has round dots connected by lines on the
@@ -46,18 +46,18 @@ When you've finished staging all your changes, you are now ready to
 make the new commit:
 
 1. Type "Generate age histograms" where it says "Message" above the Commit button.
-   This messages summarises what your staged changes do.
+   This message summarises what your staged changes do.
 1. Click the Commit button or press ++ctrl+enter++
    to *commit* the staged changes to
    add them to the repository as stored in the codespace.
 
 ![Committing changes in GitHub.](../../../images/getting-started-codespaces-commit-message.png)
 
-## Push the changes to GitHub
+## Push the changes to the remote GitHub repository
 
 The changes have been stored as a new commit in the codespace's
 *local* copy of the repository. We now need to *push* the
-repository to GitHub to make the changes show up there.
+commit to the *remote* GitHub repository, to make the changes show up there.
 
 Click the "Sync Changes" button to push your commits.  Alternatively,
 click the ellipsis (`⋯`) icon next to "Source Control" and then select
@@ -69,7 +69,7 @@ you created earlier.
 You will see a prompt: 'This action will pull and push commits from
 and to "origin/main".' — click OK.
 
-## Seeing the changes in the GitHub repository
+## Seeing the changes in the remote GitHub repository
 
 The repository was created at:
 `https://github.com/<your_github_username>/opensafely-getting-started`

--- a/docs/getting-started/tutorial/run-the-project-pipeline/index.md
+++ b/docs/getting-started/tutorial/run-the-project-pipeline/index.md
@@ -23,7 +23,7 @@ open the `project.yaml` file by clicking on it. This file will be near the end o
 
 You should see a tab with the following content:
 
-```yaml linenums="1" hl_lines="9"
+```yaml linenums="1" hl_lines="5"
 version: "4.0"
 
 actions:
@@ -48,7 +48,7 @@ stored in the `output` folder.
 <ol>
   <li>
    In the Visual Studio Code file Explorer,
-   confirm that the `output` folder is empty.
+   confirm that the <code>output</code> folder only contains a <code>.gitkeep</code> file.
   </li>
 
   <li>
@@ -59,7 +59,7 @@ stored in the `output` folder.
    opensafely run generate_dataset
    ```
 
-   and press ++enter++ to run the pipeline action.
+   and press ++enter++ on your keyboard to run the pipeline action.
 
    You should see output that ends something like the following:
 
@@ -79,14 +79,14 @@ stored in the `output` folder.
    ```
 
    The final line tells you a file of (randomly-generated) patient data has been created at
-   `output/dataset.csv.gz`, and that it should be considered highly sensitive
+   <code>output/dataset.csv.gz</code>, and that it should be considered highly sensitive
    data. What you see here is exactly the same process that would happen on a real, secure
    server.
   </li>
 
   <li>
-   When the command completes, recheck the `output` folder
-   and see that it contains a `dataset.csv.gz` file.
+   When the command completes, recheck the <code>output</code> folder
+   and see that it contains a <code>dataset.csv.gz</code> file.
    </li>
 </ol>
 
@@ -95,8 +95,11 @@ stored in the `output` folder.
 This `.csv.gz` file is a compressed CSV file that contains a small amount of *dummy data* (patient ID and sex)
 based on the dataset definition at `analysis/dataset_definition.py`.
 
-To view it, first run `opensafely unzip output`, then open that
-file (by left-clicking the filename in Visual Studio Code's Explorer, or
+To view it, first run:
+```
+opensafely unzip output
+```
+then open that file (by left-clicking the filename in Visual Studio Code's Explorer, or
 software like Excel). You'll see that it contains rows for ten
 randomly-generated dummy patients.
 


### PR DESCRIPTION
Closes #4713.

Update the OpenSafely tutorial documentation.

I went through the tutorial as part of my onboarding process and noticed some of the documentation required updating (e.g., references to incorrect line numbers). I also thought there were some opportunities to clarify or provide further information on important topics, for example, saving files locally and codespace deletion.