### PR TITLE
Update docs about ehrQL output formats

### DIFF
--- a/docs/actions-scripts.md
+++ b/docs/actions-scripts.md
@@ -137,7 +137,7 @@ These are restricted to types of file that are likely to contain summary data, r
 | Text |  `.txt`, `.log`, `.md` |
 | Data | `.csv`, `.json` |
 | Images | `.png`, `.jpeg`, `.svgz` |
-| Reports | `.html`, `.pdf` |
+| Reports | `.html`|
 
 **File size**
 

--- a/docs/actions-scripts.md
+++ b/docs/actions-scripts.md
@@ -26,8 +26,9 @@ This helps with:
 ## Reading and Writing Outputs
 
 Scripted actions can read and write output files that are saved in the workspace. These generally fall into two categories:
-* large pseudonymised patient-level files of `highly_sensitive` data for use by other actions
-* smaller `moderately_sensitive` aggregated patient-data (this should **never** be patient-level data) files for review and release
+
+  * large pseudonymised patient-level files of `highly_sensitive` data for use by other actions
+  * smaller `moderately_sensitive` aggregated patient-data (this should **never** be patient-level data) files for review and release
 
 
 ### Large `highly_sensitive` output files

--- a/docs/actions-scripts.md
+++ b/docs/actions-scripts.md
@@ -161,7 +161,16 @@ These Docker images have yet to be optimised; if you have skills in creating Doc
 
 ### Stata
 
-We currently package version 16.1, with `datacheck`, `safetab`, and `safecount` libraries installed; when installed, new libraries will appear [in the stata-docker GitHub repository](https://github.com/opensafely-core/stata-docker/tree/master/libraries).
+We currently package version 16.1, with the following libraies installed:
+
+  * `datacheck`
+  * `safetab`
+  * `safecount`
+  * `itsa`
+  * `arrowload`
+  * `gzsave`
+
+When installed, new libraries will appear [in the stata-docker GitHub repository](https://github.com/opensafely-core/stata-docker/tree/master/libraries).
 
 !!! note
     Stata can only produce very limited image formats on Linux, only eps, tiff,


### PR DESCRIPTION
Arrow is now the preferred output format.
Adds some extra info about reading arrow files in python/R/stata
Plus a couple of drive by fixes for formatting and out of date stuff on the same page.

Fixes #1691 and https://github.com/opensafely-core/ehrql/issues/2244