### PR TITLE
Remove mkdocstrings deprecation warnings

### DIFF
--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -278,9 +278,9 @@ mkdocstrings[python]==0.29.1 \
     # via
     #   -r requirements.prod.in
     #   mkdocstrings-python
-mkdocstrings-python==1.16.2 \
-    --hash=sha256:942ec1a2e0481d28f96f93be3d6e343cab92a21e5baf01c37dd2d7236c4d0bd7 \
-    --hash=sha256:ff7e719404e59ad1a72f1afbe854769984c889b8fa043c160f6c988e1ad9e966
+mkdocstrings-python==1.16.8 \
+    --hash=sha256:211b7aaf776cd45578ecb531e5ad0d3a35a8be9101a6bfa10de38a69af9d8fd8 \
+    --hash=sha256:9453ccae69be103810c1cf6435ce71c8f714ae37fef4d87d16aa92a7c800fe1d
     # via mkdocstrings
 mypy-extensions==1.0.0 \
     --hash=sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d \


### PR DESCRIPTION
This removes deprecation warnings when running `mkdocs` such as:

```
INFO    -  DeprecationWarning: Importing from `mkdocstrings.handlers.base` is deprecated. Import from `mkdocstrings` directly.
…
```