### PR TITLE
Enable improved tooltips

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ theme:
   features:
     - content.action.edit
     - content.code.copy
+    - content.tooltips
     - navigation.footer
     - navigation.indexes
 


### PR DESCRIPTION
> When improved tooltips are enabled, Material for MkDocs replaces the browser's rendering logic for title attribute with beautiful little tooltips.

[Source](https://squidfunk.github.io/mkdocs-material/reference/tooltips/?h=abbr#improved-tooltips)

## Screenshots

### Before

![Default tooltip on HTML abbr tag](https://github.com/user-attachments/assets/16d59767-eb4c-4125-ba9c-2ca887af0a72)

### After

![Popover tooltip](https://github.com/user-attachments/assets/7d0afcaa-1d11-4031-80ac-233fd2e4c49d)

