### PR TITLE
Update jupyter launch command

### DIFF
--- a/docs/opensafely-cli.md
+++ b/docs/opensafely-cli.md
@@ -255,7 +255,7 @@ you write will work in the OpenSAFELY environment too.
 From the directory containing code that you are working on, run:
 
 ```bash
-opensafely jupyter
+opensafely launch jupyter
 ```
 
 JupyterLab should then open in a web browser automatically. Otherwise,


### PR DESCRIPTION
We've introduced the `opensafely launch` command since this documentation was written. This deprecates the `opensafely jupyter` command and we've already updated the documentation in other places.

Refs: #1579