### PR TITLE
Use `wrangler-action` to deploy to Cloudflare Pages

### DIFF
--- a/.github/workflows/pages-deployment.yml
+++ b/.github/workflows/pages-deployment.yml
@@ -39,10 +39,9 @@ jobs:
 
       - name: Publish
         if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca  # v1.5.0
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_DIRECT_UPLOAD_API_TOKEN }}
-          directory: "site"
+          command: pages deploy site --project-name=opensafely-docs
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          projectName: "opensafely-docs"


### PR DESCRIPTION
Fixes #1604.

This project uses `cloudflare/pages-action` to deploy to Cloudflare Pages, but that action is now deprecated with the latest release being `v1.5.0` ([source](https://github.com/cloudflare/pages-action?tab=readme-ov-file)). The remedy is to move to the Cloudflare Wrangler Action, requiring small edits to the `pages-deployent.yml`.