### PR TITLE
Revert "Merge pull request #1877

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -39,7 +39,7 @@ jobs:
       # https://github.com/lycheeverse/lychee/issues/36
       - name: Check links
         # 2.6.1 seemed to cause the exclude-path to not take effect, waiting for next release.
-        uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0  # v2.7.0
+        uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332  # v2.4.1
         with:
           args: "--exclude-all-private --include-verbatim --max-concurrency 24 --require-https --verbose --no-progress --offline
           --accept '100..=103,200..=299,429,500..=511'


### PR DESCRIPTION
This reverts commit 10ab8a6ec7334d2e1c07a51616e8e54d4210ea2d, reversing changes made to 50b86bcc99a3a9c11a9266cd4d29f8b54c7a1a96 to bump the version of lyche-action to v2.7.

The link checker initially worked, but started failing after some changes to the ehrQL docs were merged. We think this might be due to the known issue in v2.6.1 causing the exclude-path not to work.

Rerunning the [check links action](https://github.com/opensafely/documentation/actions/runs/21487432229) on this branch has succeeded, suggesting the version bump was the issue.

Fixes https://github.com/opensafely/documentation/issues/1907