### PR TITLE
Add placeholder "OpenSAFELY data" page

### DIFF
--- a/docs/opensafely-data/index.md
+++ b/docs/opensafely-data/index.md
@@ -1,0 +1,1 @@
+Detailed description of data available in OpenSAFELY coming soon.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,8 @@ nav:
       - Access policies: access-policies.md
       - A high level overview of how OpenSAFELY works: how-opensafely-works.md
       - Technical architecture: technical-architecture.md
+      - OpenSAFELY data:
+          - OpenSAFELY data: opensafely-data/index.md
       - Type One Opt-Outs: type-one-opt-outs.md
       - National Data Opt-Outs: national-data-opt-outs.md
       - Contributing: contributing.md


### PR DESCRIPTION
See #1912 

I've added this in a new folder on the assumption that there might be a few different pieces of data and separating them out to different files could be useful (e.g. we already have a page on NDOO and T1OO that probably fit in this new OpenSAFELY data section - moving those around isn't in scope for this ticket). 
If separate files aren't needed, it can all go in the one index.md file and nothing is visibly different.