### PR TITLE
Documentation updates for researchers

### DIFF
--- a/docs/getting-started/how-to/create-a-code-repository-for-your-project/index.md
+++ b/docs/getting-started/how-to/create-a-code-repository-for-your-project/index.md
@@ -7,43 +7,10 @@
 
 You only need to create a code repository once for a particular project.
 
-Create a new research code repository based on the research template.
 
-1. In your web browser,
-   go to the [research code template repository](https://github.com/opensafely/research-template).
-1. Click the "Use this template" button
-   to begin the process of creating a new research code repository for you to work on.
-   The screenshot below shows this.
+To create a repository for your OpenSAFELY project, you can either:
 
-![A screenshot showing the "Use this template" button for the research code template repository.](../../../images/codespaces-template.png)
+- Have a new repository created for you in the `opensafely` GitHub organisation
+- Create a repository in your own GitHub account, and request to have this transferred to the `opensafely` GitHub organisation later
 
-There are several options given
-when creating a new repository from a template.
-
-Here is a quick explanation of the options:
-
-* If you are creating a repository for an OpenSAFELY project,
-  you should choose `opensafely` as the repository owner.
-* If you are creating a repository for testing OpenSAFELY out,
-  you should choose *your own GitHub user account* as the repository owner.
-* You can enter any name and description that you choose for your repository.
-* You can choose whether the repository visibility is public or private.
-* You do not need to select "Include all branches".
-* You can ignore the mention of "GitHub Apps from GitHub Marketplace"
-  in GitHub's instructions for creating a new repository from a template.
-
-If you are unsure of what to do,
-refer to GitHub's step-by-step instructions for [creating a new repository from a template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template#creating-a-repository-from-a-template).
-
-!!! warning
-    Creating a repository owned by your GitHub user account
-    will enable you to:
-
-    * work on your OpenSAFELY research code in Codespaces
-    * check that your research code works with the OpenSAFELY platform
-
-    **It will not allow you to run code on OpenSAFELY's platform.**
-
-    For that, you would have to request that your repository is transferred to the `opensafely` organization.
-
-    Approved OpenSAFELY users are able to create a repository within the `opensafely` organization directly.
+You can find more information about both of these options in the [creating a repository for a project](../../../repositories.md/#creating-a-repository-for-a-project) section of the OpenSAFELY documentation.

--- a/docs/getting-started/how-to/create-a-code-repository-for-your-project/index.md
+++ b/docs/getting-started/how-to/create-a-code-repository-for-your-project/index.md
@@ -8,7 +8,7 @@
 You only need to create a code repository once for a particular project.
 
 
-To create a repository for your OpenSAFELY project, you can either:
+To create a repository for your OpenSAFELY research project, you can either:
 
 - Have a new repository created for you in the `opensafely` GitHub organisation
 - Create a repository in your own GitHub account, and request to have this transferred to the `opensafely` GitHub organisation later

--- a/docs/jobs-site.md
+++ b/docs/jobs-site.md
@@ -4,12 +4,13 @@ The [jobs site](https://jobs.opensafely.org/) is where you can run your code on 
 
 The jobs site is centred around **Projects**. When an application to run a study in OpenSAFELY is [approved by the data controller](https://www.opensafely.org/onboarding-new-users/), a _Project_ is automatically created. You can see a [list of approved projects, and the organisation they belong to](https://www.opensafely.org/approved-projects/).
 
-We will add any GitHub usernames listed in your approval to our `opensafely` [GitHub organisation](https://github.com/opensafely). We will also ask you to [transfer](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository) your existing OpenSAFELY study repository (if you have one) into the same organisation. This allows OpenSAFELY to enforce certain security standards, such as [multi-factor authentication](https://docs.github.com/en/github/authenticating-to-github/securing-your-account-with-two-factor-authentication-2fa).
+We will add any GitHub usernames listed in your approval to our `opensafely` [GitHub organisation](https://github.com/opensafely). We will also ask you to [transfer](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository#transferring-a-repository-owned-by-your-personal-account) your existing OpenSAFELY study repository (if you have one) into the same organisation. This allows OpenSAFELY to enforce certain security standards, such as [multi-factor authentication](https://docs.github.com/en/github/authenticating-to-github/securing-your-account-with-two-factor-authentication-2fa).
 
 !!! warning
-    It is important that the study repository is _transferred_ into the `opensafely` organization, not _forked_ into it. Please [ask us](how-to-get-help.md#slack) if you have any problems with this process.
+    It is important that the study repository is _transferred_ into the `opensafely` organization, not forked into it. You can request to transfer your existing OpenSAFELY study repository by following the process outlined [here](repositories.md/#how-to-transfer-an-existing-repository-to-the-opensafely-organization).
 
-Within each _Project_, there are one or more **Workspaces**, which are linked to a GitHub repository in the [OpenSAFELY organisation](https://github.com/opensafely). Any [actions](actions-intro.md) you develop as part of your [project pipeline](actions-pipelines.md) within the attached repository are linked to the workspace, allowing these to be run against real data.
+
+Within each _Project_, there are one or more **Workspaces**, which are linked to a GitHub repository in the [`opensafely` organisation](https://github.com/opensafely). Any [actions](actions-intro.md) you develop as part of your [project pipeline](actions-pipelines.md) within the attached repository are linked to the workspace, allowing these to be run against real data.
 
 A _Job_ is an instance of an _Action_ running on real data. _Jobs_ are run by selecting one or more actions to be run as part of a single _Job Request_. You can see all the _Job Requests_ that have been run from a _Workspace_ by clicking on "View logs" from a _Workspace_ page. You can see a [log of all _Job Requests_ being run](https://jobs.opensafely.org/event-log/).
 
@@ -69,7 +70,7 @@ There are some additional roles linked to the release of outputs from the server
 
 #### Viewing and requesting changes to your permissions
 
-You can view the permissions you have for your project by navigating to the _Project_ page, where can see the permissions for all researchers involved in your project.
+You can view the permissions you have for your project by navigating to the _Project_ page (see arrow below), where you can see the permissions for all researchers involved in your project.
 
 ![Jobs site project page](./images/view_project.png)
 
@@ -86,7 +87,7 @@ If you are not able to do any of the tasks and you think you should, please cont
     * Select the repo and branch whose action you want to run (in most cases, the branch will be either `main` or `master`)
     * Click `Create workspace`
 
-When you add a new repository in the [`opensafely` organisation](https://github.com/opensafely), it may take up to 15 mintutes for it to be available to select at [https://jobs.opensafely.org](https://jobs.opensafely.org).
+When a new repository is added to the [`opensafely` organisation](https://github.com/opensafely), it may take up to 15 mintutes for it to be available to select at [https://jobs.opensafely.org](https://jobs.opensafely.org).
 
 ![Create a new workspace button on the project page](./images/create_new_workspace_1.png)
 

--- a/docs/jobs-site.md
+++ b/docs/jobs-site.md
@@ -6,8 +6,8 @@ The jobs site is centred around **Projects**. When an application to run a study
 
 We will add any GitHub usernames listed in your approval to our `opensafely` [GitHub organisation](https://github.com/opensafely). We will also ask you to [transfer](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository#transferring-a-repository-owned-by-your-personal-account) your existing OpenSAFELY study repository (if you have one) into the same organisation. This allows OpenSAFELY to enforce certain security standards, such as [multi-factor authentication](https://docs.github.com/en/github/authenticating-to-github/securing-your-account-with-two-factor-authentication-2fa).
 
-!!! warning
-    It is important that the study repository is _transferred_ into the `opensafely` organization, not forked into it. You can request to transfer your existing OpenSAFELY study repository by following the process outlined [here](repositories.md/#how-to-transfer-an-existing-repository-to-the-opensafely-organization).
+!!! info
+    You can request to transfer your existing OpenSAFELY study repository by following the [outlined process](repositories.md/#how-to-transfer-an-existing-repository-to-the-opensafely-organization).
 
 
 Within each _Project_, there are one or more **Workspaces**, which are linked to a GitHub repository in the [`opensafely` organisation](https://github.com/opensafely). Any [actions](actions-intro.md) you develop as part of your [project pipeline](actions-pipelines.md) within the attached repository are linked to the workspace, allowing these to be run against real data.
@@ -87,7 +87,7 @@ If you are not able to do any of the tasks and you think you should, please cont
     * Select the repo and branch whose action you want to run (in most cases, the branch will be either `main` or `master`)
     * Click `Create workspace`
 
-When a new repository is added to the [`opensafely` organisation](https://github.com/opensafely), it may take up to 15 mintutes for it to be available to select at [https://jobs.opensafely.org](https://jobs.opensafely.org).
+When a new repository is added to the [`opensafely` organisation](https://github.com/opensafely), it may take up to 15 minutes for it to be available to select at [https://jobs.opensafely.org](https://jobs.opensafely.org).
 
 ![Create a new workspace button on the project page](./images/create_new_workspace_1.png)
 

--- a/docs/project-completion.md
+++ b/docs/project-completion.md
@@ -27,7 +27,7 @@ Ensure your repo is as tidy as possible once you have completed your project. Co
 
 
 ### License
-Check your repo has a `LICENSE` file.  We recommend the [MIT licence](https://opensource.org/license/mit), as it is an [open source license with strong community support](https://opensource.org/licenses?categories=popular-strong-community) and allows modification and distribution without cost. An MIT License has been included as part of the research template repository; you will need to edit the first line to include the current year and the name of your organisation. 
+Check your repo has a `LICENSE` file.  We recommend the [MIT licence](https://opensource.org/license/mit), as it is an [open source license with strong community support](https://opensource.org/licenses?categories=popular-strong-community) and allows modification and distribution without cost. An MIT License has been included as part of the research template repository; you will need to edit the first line to include the current year and the name of your organisation.
 
 
 ### Tests
@@ -69,7 +69,7 @@ You will be prompted to check various bits of metadata associated with the repos
 Once you have completed this page it will be checked by the OpenSAFELY team before being made public.
 
 !!! info
-    You will be prompted to make it public sooner, if you first ran the code against an OpenSAFELY database more than 12 months ago.
+    Private repositories within the opensafely GitHub organisation are made public after 12 months. This means that your repository may be made public before project completion, if you first ran the code against an OpenSAFELY database more than 12 months ago. You can find more information about repository visibility and how this is managed [here](repositories.md/#repository-visibility).
 
 ## Make your outputs on the jobs site public
 

--- a/docs/project-completion.md
+++ b/docs/project-completion.md
@@ -69,7 +69,7 @@ You will be prompted to check various bits of metadata associated with the repos
 Once you have completed this page it will be checked by the OpenSAFELY team before being made public.
 
 !!! info
-    Private repositories within the opensafely GitHub organisation are made public after 12 months. This means that your repository may be made public before project completion, if you first ran the code against an OpenSAFELY database more than 12 months ago. You can find more information about repository visibility and how this is managed [here](repositories.md/#repository-visibility).
+    Private repositories within the opensafely GitHub organisation are made public after 12 months. This means that your repository may be made public before project completion, if you first ran the code against an OpenSAFELY database more than 12 months ago. You can find more information about repository visibility and how this is managed in the [Repository visibility](repositories.md/#repository-visibility) section of our documentation.
 
 ## Make your outputs on the jobs site public
 

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -9,7 +9,23 @@ GitHub is the means by which code in the repository is passed to the server to b
 
 ## Repository visibility
 
-In accordance with the [Principles of OpenSAFELY](https://www.opensafely.org/about/#transparency-and-public-logs), we expect all code from all users to be made public. As technical users will know, a public GitHub repository is visible by anyone on the internet, but only specified people will have the ability to change it.
+In accordance with the [Principles of OpenSAFELY](https://www.opensafely.org/about/#transparency-and-public-logs), we expect all code from all users to be made public.
+
+By default, repositories will initially be public, visible to anyone. Repositories may be temporarily set to private, visible to members of the opensafely organization only, [by request](#how-to-make-your-repository-private).
+
+### How to make your repository private
+
+Contact [Tech Support](how-to-get-help.md/#slack) to request that your repository is made private at any time.
+
+If your request is approved, Tech Support will make your repository private and you will be notified once this has been completed.
+
+Private repositories will be made public after 12 months. Ahead of that, you can make a new request to extend the private visibility period for another 12 months.
+
+!!! info
+    A repository must be made public if it forms part of a publication.
+
+    Refer to our documentation on [when you need to make your code public](#when-you-need-to-make-your-code-public), for more information.
+
 
 ### How to make your code public
 
@@ -21,26 +37,83 @@ In earlier versions of OpenSAFELY, all results released from the secure server a
 
 ### When you need to make your code public
 
-A repository must be made public if it forms part of a [publication](https://www.opensafely.org/policies-for-researchers/#acknowledgment-and-data-sharing--publication-policy). We have a [guide to publishing repositories](project-completion.md) that you must read. During the development stage of a project, a repository may be kept private, so that only members of the OpenSAFELY GitHub organisation are able to view it. We welcome people sharing code in public while they are developing, where they wish to do so, but we recognise that for many this would be a little like drafting a paper entirely in public, so it is not a requirement. Even when there is no publication, we expect all repositories to become public, within twelve months after first code execution. During our pilot phase of OpenSAFELY Users, if we encounter edge cases proposing that a particular repo should be excepted from this policy we will develop an open and structured Exceptions Process.
+A repository must be made public if it forms part of a [publication](https://www.opensafely.org/policies-for-researchers/#acknowledgment-and-data-sharing--publication-policy). We have a [guide to publishing repositories](project-completion.md) that you must read. During the development stage of a project, a repository may be kept private, so that only members of the [`opensafely` GitHub organisation](https://github.com/opensafely) are able to view it. We welcome people sharing code in public while they are developing, where they wish to do so, but we recognise that for many this would be a little like drafting a paper entirely in public, so it is not a requirement. Even when there is no publication, we expect all repositories to become public, within twelve months after first code execution.
 
 !!! warning
     You should _never_ commit files or content that should not be made public to the repository. All committed files, whether on the `main` branch or on development branches, will remain in the git history of the repository even after they have been deleted. These might include for example patient- or commercially-sensitive data from other sources, internal institutional documentation or forms, and incomplete manuscript drafts.
 
-## Creating a repository for a new project
+## Creating a repository for a project
+
+To create a repository for your OpenSAFELY project, you can either:
+
+- Have a new repository created for you in the `opensafely` GitHub organisation
+- Create a repository in your own GitHub account, and request to have this transferred to the `opensafely` GitHub organisation later
+
+### Default opensafely repository settings
+
+Any repositories created within, or transferred to, the `opensafely` organisation, will be configured with the settings, listed below:
+
+- Deletion of branches on merge: enabled
+- Branch protection for `master` and `main` branches: enabled
+- Require a pull request review before merging: disabled
+
+### New researchers and projects
+
+When you are approved to start working on an OpenSAFELY research project, you will be added to the `opensafely` GitHub organisation. Within the `opensafely` GitHub organisation, you’ll be added to the `researchers` team.
+
+Contact [Tech Support](how-to-get-help.md/#slack) and ask them to create a new repository for your research, or transfer a repository from your personal GitHub account into the `opensafely` GitHub organisation (depending on your preference, and whether you have an existing repository to transfer).
+
+Newly-created and trasnferred repositories will be configured with the settings listed in [Default `opensafely` repository settings](#default-opensafely-repository-settings), above.
+
+Repositories will initially be public, but may be (temporarily) set to private at your request. See [Repository visibility](#repository-visibility) to make the right choice for your study.
+
+### Established researchers and projects
+
+Contact [Tech Support](how-to-get-help.md/#slack) to request the creation of any additional repositories you require. Please provide a name for the repository when you make a request. Your repository name should be short but informative &mdash; browse [existing repo names](https://github.com/orgs/opensafely/repositories) for inspiration.
+
+All repositories will be created using the OpenSAFELY [research-template repo](https://github.com/opensafely/research-template). You can see a detailed breakdown of this repository’s structure in [Repository structure](#repository-structure).
+
+## Transferring your own repository to the `opensafely` GitHub organisation
+
+You may want to start work on a project before approval by creating a repository in your own GitHub account (see [instructions for how to do this](#creating-a-research-repository-in-your-own-github-account-so-that-you-can-transfer-it-later), below). You can request that this repository is transferred to the `opensafely` organisation at a later date.
+
+!!! warning
+    Creating a repository owned by your GitHub user account will enable you to:
+
+    - work on your OpenSAFELY research code in Codespaces
+    - check that your research code works with the OpenSAFELY platform
+
+    It will not allow you to run code on OpenSAFELY's platform. For that, you would have to request that your repository is transferred to the `opensafely` organization.
+
+### How to transfer an existing repository to the opensafely organization
+
+To transfer a repository from your personal GitHub account to the OpenSAFELY organisation, follow the instructions [here](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository#transferring-a-repository-owned-by-your-personal-account). You will then need to contact [Tech Support](how-to-get-help.md/#slack), to request approval for the repository transfer.
+
+If your request is approved, Tech Support will notify you once the transfer has been completed. You will also be able to see the repository on the `opensafely` organisation [Repositories page](https://github.com/orgs/opensafely/repositories).
+
+The settings of any transferred repositories will be updated to match the default `opensafely` repository settings, listed below:
+
+- Deletion of branches on merge: enabled
+- Branch protection for `master` and `main` branches: enabled
+- Require a pull request before merging: disabled
+
+### Creating a research repository in your own GitHub account so that you can transfer it later
 
 For ease of use, we have created a research template that you should use for your study.
-Go to the [OpenSAFELY research template repo](https://github.com/opensafely/research-template) on GitHub.
+Go to the [OpenSAFELY research-template repo](https://github.com/opensafely/research-template) on GitHub.
 Click the green button that says <span style="background-color: green; color: white">&nbsp;**Use this template**&nbsp;</span>.
 
 Fill in the details:
 
-- **owner**: select your personal GitHub for testing/experimenting, or select the `opensafely` organisation for a bona fide OpenSAFELY-approved study. The repo can be transferred into the `opensafely` organisation later if needed.
-- **repository name**: It needs to be short but informative &mdash; browse existing repo names for inspiration.
-- **Description**: This will appear at the top of the repo on GitHub. No more than a sentence is needed as the repo should be explained fully in the README.
+- **owner**: Select your personal GitHub for testing/experimenting.
+- **repository name**: It needs to be short but informative &mdash; browse [existing repo names](https://github.com/orgs/opensafely/repositories) for inspiration.
+- **description**: This will appear at the top of the repo on GitHub. No more than a sentence is needed as the repo should be explained fully in the `README.md`.
 - **public / private**: See [Repository visibility](#repository-visibility) to make the the right choice for your study.
 - **Include all branches**: Leave unchecked.
 
 And submit. You will now be at the GitHub landing page for the repo.
+
+If you are unsure of what to do, refer to GitHub's step-by-step instructions for [creating a new repository from a template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template#creating-a-repository-from-a-template).
 
 You should also download a copy of this repo to your machine so you can work on it locally.
 This is necessary because you can:
@@ -48,7 +121,7 @@ This is necessary because you can:
 * develop your code using familiar editing tools
 * test and run code without disturbing other contributors
 
-To clone your new repository to your machine, [follow these instructions](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) which explains cloning both via GitHub Desktop or via the command line.
+To clone your new repository to your machine, [follow these instructions](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) which explains cloning both via GitHub Desktop or via the command line.
 When this is done, you should have a folder whose name is the same as the repo on your machine.
 
 Note that if someone else wants to commit to your recently created OpenSAFELY repo, they may need to wait up to an hour for the necessary write permissions to be granted.
@@ -132,4 +205,4 @@ This can be useful if you want to, for example, add a `output/plots/` subfolder 
 
 ## Searching existing repositories for sample code
 
-Often when writing study code, it can be useful to see how others have solved certain problems or used ehrQL features. To search all the public code in the OpenSAFELY GitHub organisation, see instructions in our [How to Get Help page](how-to-get-help.md#searching-past-study-code).
+Often when writing study code, it can be useful to see how others have solved certain problems or used ehrQL features. To search all the public code in the `opensafely` GitHub organisation, see instructions in our [How to Get Help page](how-to-get-help.md#searching-past-study-code).

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -11,7 +11,7 @@ GitHub is the means by which code in the repository is passed to the server to b
 
 In accordance with the [Principles of OpenSAFELY](https://www.opensafely.org/about/#transparency-and-public-logs), we expect all code from all users to be made public.
 
-By default, repositories will initially be public, visible to anyone. Repositories may be temporarily set to private, visible to members of the opensafely organization only, [by request](#how-to-make-your-repository-private).
+By default, repositories will initially be public, visible to anyone. Repositories may be temporarily set to private, visible to members of the `opensafely` GitHub organization only, [by request](#how-to-make-your-repository-private).
 
 ### How to make your repository private
 
@@ -37,7 +37,7 @@ In earlier versions of OpenSAFELY, all results released from the secure server a
 
 ### When you need to make your code public
 
-A repository must be made public if it forms part of a [publication](https://www.opensafely.org/policies-for-researchers/#acknowledgment-and-data-sharing--publication-policy). We have a [guide to publishing repositories](project-completion.md) that you must read. During the development stage of a project, a repository may be kept private, so that only members of the [`opensafely` GitHub organisation](https://github.com/opensafely) are able to view it. We welcome people sharing code in public while they are developing, where they wish to do so, but we recognise that for many this would be a little like drafting a paper entirely in public, so it is not a requirement. Even when there is no publication, we expect all repositories to become public, within twelve months after first code execution.
+A repository must be made public if it forms part of a [publication](https://www.opensafely.org/policies-for-researchers/#acknowledgment-and-data-sharing--publication-policy). We have a [guide to publishing repositories](project-completion.md) that you must read. During the development stage of a project, a [repository may be kept private](#how-to-make-your-repository-private), so that only members of the [`opensafely` GitHub organisation](https://github.com/opensafely) are able to view it. We welcome people sharing code in public while they are developing, where they wish to do so, but we recognise that for many this would be a little like drafting a paper entirely in public, so it is not a requirement. Even when there is no publication, we expect all repositories to become public, within twelve months after first code execution.
 
 !!! warning
     You should _never_ commit files or content that should not be made public to the repository. All committed files, whether on the `main` branch or on development branches, will remain in the git history of the repository even after they have been deleted. These might include for example patient- or commercially-sensitive data from other sources, internal institutional documentation or forms, and incomplete manuscript drafts.
@@ -49,33 +49,35 @@ To create a repository for your OpenSAFELY project, you can either:
 - Have a new repository created for you in the `opensafely` GitHub organisation
 - Create a repository in your own GitHub account, and request to have this transferred to the `opensafely` GitHub organisation later
 
-### Default opensafely repository settings
+### Default repository settings in the GitHub `opensafely` organisation
 
 Any repositories created within, or transferred to, the `opensafely` organisation, will be configured with the settings, listed below:
 
 - Deletion of branches on merge: enabled
-- Branch protection for `master` and `main` branches: enabled
+- Branch protection for `master` and `main` branches: enabled (mandatory)
 - Require a pull request review before merging: disabled
+
+You can [contact Tech Support](how-to-get-help.md/#slack) to request changes to your repository settings; those listed as *mandatory* above cannot be changed.
 
 ### New researchers and projects
 
-When you are approved to start working on an OpenSAFELY research project, you will be added to the `opensafely` GitHub organisation. Within the `opensafely` GitHub organisation, you’ll be added to the `researchers` team.
+When you are approved to start working on an OpenSAFELY research project, you will be added to the `opensafely` GitHub organisation to provide repository access.
 
 Contact [Tech Support](how-to-get-help.md/#slack) and ask them to create a new repository for your research, or transfer a repository from your personal GitHub account into the `opensafely` GitHub organisation (depending on your preference, and whether you have an existing repository to transfer).
 
-Newly-created and trasnferred repositories will be configured with the settings listed in [Default `opensafely` repository settings](#default-opensafely-repository-settings), above.
+Newly-created and transferred repositories will be configured with the settings listed in [default `opensafely` repository settings](#default-opensafely-repository-settings), above.
 
-Repositories will initially be public, but may be (temporarily) set to private at your request. See [Repository visibility](#repository-visibility) to make the right choice for your study.
+Repositories will initially be public, but may be temporarily set to private at your request. See [Repository visibility](#repository-visibility) to make the right choice for your study.
 
 ### Established researchers and projects
 
 Contact [Tech Support](how-to-get-help.md/#slack) to request the creation of any additional repositories you require. Please provide a name for the repository when you make a request. Your repository name should be short but informative &mdash; browse [existing repo names](https://github.com/orgs/opensafely/repositories) for inspiration.
 
-All repositories will be created using the OpenSAFELY [research-template repo](https://github.com/opensafely/research-template). You can see a detailed breakdown of this repository’s structure in [Repository structure](#repository-structure).
+All repositories will be created using the OpenSAFELY [research-template repo](https://github.com/opensafely/research-template). Refer to the [detailed breakdown of this repository’s structure](#repository-structure).
 
 ## Transferring your own repository to the `opensafely` GitHub organisation
 
-You may want to start work on a project before approval by creating a repository in your own GitHub account (see [instructions for how to do this](#creating-a-research-repository-in-your-own-github-account-so-that-you-can-transfer-it-later), below). You can request that this repository is transferred to the `opensafely` organisation at a later date.
+You may want to start work on a project before approval by [creating a repository in your own GitHub account](#creating-a-research-repository-in-your-own-github-account-so-that-you-can-transfer-it-later). You can request that this repository is transferred to the `opensafely` organisation at a later date.
 
 !!! warning
     Creating a repository owned by your GitHub user account will enable you to:
@@ -87,15 +89,13 @@ You may want to start work on a project before approval by creating a repository
 
 ### How to transfer an existing repository to the opensafely organization
 
-To transfer a repository from your personal GitHub account to the OpenSAFELY organisation, follow the instructions [here](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository#transferring-a-repository-owned-by-your-personal-account). You will then need to contact [Tech Support](how-to-get-help.md/#slack), to request approval for the repository transfer.
+To transfer a repository from your personal GitHub account to the OpenSAFELY organisation:
 
-If your request is approved, Tech Support will notify you once the transfer has been completed. You will also be able to see the repository on the `opensafely` organisation [Repositories page](https://github.com/orgs/opensafely/repositories).
+1. Follow [GitHub's instructions](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository#transferring-a-repository-owned-by-your-personal-account) to initiate a transfer.
+2. Contact [Tech Support](how-to-get-help.md/#slack) to request approval for the repository transfer.
+3. Tech Support will notify you once the transfer has been completed. You will also be able to see the repository listed in the [`opensafely` organisation](https://github.com/orgs/opensafely/repositories) once transferred.
 
-The settings of any transferred repositories will be updated to match the default `opensafely` repository settings, listed below:
-
-- Deletion of branches on merge: enabled
-- Branch protection for `master` and `main` branches: enabled
-- Require a pull request before merging: disabled
+The settings of any transferred repositories will be updated to match the [default `opensafely` repository settings](#default-repository-settings-in-the-github-opensafely-organisation).
 
 ### Creating a research repository in your own GitHub account so that you can transfer it later
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -5,8 +5,7 @@ The following assumes that a well-defined and ethically-approved research agenda
 
 The workflow for a single study can typically be broken down into the following steps:
 
-1.  **Create a git repository** from the [template repository provided](https://github.com/opensafely/research-template) and clone it on your local machine.
-This repo will contain all the code relating to your project, and a history of its development over time.
+1.  **Clone your `opensafely` research repository** from GitHub onto your local machine. This repo will contain all the code relating to your project, and a history of its development over time.
 2.  **Write a [dataset definition](ehrql/index.md)** that specifies what data you want to extract from the database:
     -   specify the patient population (dataset rows) and variables (dataset columns)
     -   specify the expected distributions of these variables for use in dummy data


### PR DESCRIPTION
Closes [#433](https://github.com/bennettoxford/sysadmin/issues/433).

This PR updates the OpenSAFELY documentation, following changes to our processes around repo creation, transfer, and management, as part of [#429](https://github.com/bennettoxford/sysadmin/issues/429).

### Questions for reviewer(s)

1. Does the flow of the updated docs make sense?
2. Do we want to add a note to researchers in the "Default opensafely repository settings" section, to let them know they can request alternative settings e.g., require 'n' reviews on a pull request?