### PR TITLE
remove refs to qa forum

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -11,10 +11,6 @@ We welcome proposals for longer topic-based guides. Suggest them as an [issue in
 ## Reusable actions
 These are [units of software that solve a problem for several studies](./actions-reusable.md) without the need to copy-and-paste between them. They can be shared between researchers, even between groups that use different programming languages, and are one of the best ways you can make contributions that benefit the community. If you've written a reusable action you'd like to contribute to the actions library, please get in touch at [team@opensafely.org](mailto:team@opensafely.org).
 
-## Peer support
-
-We encourage researchers to post questions in the [Q&A Forum](https://github.com/opensafely/documentation/discussions). We would love more people to chip in and attempt to answer questions!
-
 ## Core code
 We would like to accept _ad hoc_ contributions to the [core code](https://github.com/opensafely-core/), but this is relatively hard for us to do. New features and bugfixes need a lot work from our side to integrate and maintain, because a lot of the design and prioritisation decisions are made with lots of different parts of the framework in mind. Most code changes have an associated administrative and legal burden: we need to secure contributor agreements from individuals or their employers.  We plan to seek funding to help resource this kind of work, as we believe it can really strengthen and build our community, but for the time being, we suggest [filing bug reports or feature requests](https://github.com/opensafely-core) rather than contributing code.
 

--- a/docs/copiloting-service.md
+++ b/docs/copiloting-service.md
@@ -8,7 +8,7 @@ The service includes five days (over four weeks) of dedicated 1:1 support with c
 
 Beyond this initial four week period, we also provide:
 
-- community support via GitHub forums and the `#opensafely-users` Slack channel
+- community support via the `#opensafely-users` Slack channel
 - output checking service
 - manuscript review
 - opportunities to present at quarterly OpenSAFELY User Group meetings
@@ -108,7 +108,7 @@ Please note that co-pilots will not perform code review of any analysis scripts 
 
 ## What happens after the co-piloting period is over (the 'post co-piloting stage')?
 
-It is not expected that the research project will be complete at the end of the active co-piloting period, rather that the pilot will have acquired the relevant experience to complete the project independently. All community resources (the [discussion forum](https://github.com/opensafely/documentation/discussions) and the `#opensafely-users` Slack channel) will remain accessible to the pilots but regular, dedicated 1:1 support for study implementation will end. The co-pilot will remain involved in the project over the long term in terms of output checking and manuscript review.
+It is not expected that the research project will be complete at the end of the active co-piloting period, rather that the pilot will have acquired the relevant experience to complete the project independently. The community resources (the `#opensafely-users` Slack channel) will remain accessible to the pilots but regular, dedicated 1:1 support for study implementation will end. The co-pilot will remain involved in the project over the long term in terms of output checking and manuscript review.
 
 All OpenSAFELY outputs require approval from NHS England before they can be disseminated any wider than the pilot's research group. This includes academic manuscripts (pre-printed or peer-reviewed), conference abstracts and presentations, internal reports and masters/PhD theses. Our IG team will handle the NHS England approval process; for more information about how to request NHS England approval and what to include in your publication text please see [this section of our documentation](https://www.opensafely.org/policies-for-researchers/).
 

--- a/docs/getting-started/tutorial/introduction/index.md
+++ b/docs/getting-started/tutorial/introduction/index.md
@@ -24,8 +24,6 @@ You will:
 6. Add an analysis step to the study
 6. Run the study in a testing environment
 
-Please ask any questions in our [Q&A forum](https://github.com/opensafely/documentation/discussions)!
-
 ## Requirements
 
 The requirements for this tutorial are minimal.

--- a/docs/how-to-get-help.md
+++ b/docs/how-to-get-help.md
@@ -1,19 +1,8 @@
-## Q&A forum
-
-If you're outside the co-pilot programme,
-then your first port of call should be to ask your question in the [Q&A forum][].
-Before asking your question,
-please search the [Q&A forum][] and the OpenSAFELY documentation,
-to check that your question hasn’t already been answered.
-
-[Q&A forum]: https://github.com/opensafely/documentation/discussions
-
 ## Slack
 
 You will be invited to join the Bennett Institute's workspace during the co-pilot programme.
 If you're outside the co-pilot programme,
 then your second port of call should be to ask your question in any channel to which you have access.
-(Your first port of call should be to ask your question in the [Q&A forum](#qa-forum).)
 
 You may wish to direct your question to the **tech support team**.
 To do so, include the string `tech-support` in your question
@@ -78,7 +67,7 @@ Issues can be submitted for lots of different things &mdash; new variables or ot
 
 The most common requests are about library support; this page describes [how to request new libraries](requesting-libraries.md). If you want to report bugs or request features in the `opensafely` command-line tool, you can do so in [its own dedicated issue tracker](https://github.com/opensafely-core/opensafely-cli/issues).
 
-Other than this, you will need to choose the most appropriate repo to submit an issue. If you're not sure where to submit your issue, just ask a question in our [Q&A forum](https://github.com/opensafely/documentation/discussions) and we can point you to the right place.
+Other than this, you will need to choose the most appropriate repo to submit an issue.
 
 ## Data providers
 

--- a/docs/how-to-get-help.md
+++ b/docs/how-to-get-help.md
@@ -73,9 +73,6 @@ Other than this, you will need to choose the most appropriate repo to submit an 
 
 We have information on [integration](system-integration.md) elsewhere in this documentation.
 
-For general questions on getting a local integration running,
-please use our [Q&A forum](https://github.com/opensafely/documentation/discussions).
-
 To discuss making your data available to researchers via the OpenSAFELY
 platform, please [contact our technical
 team](mailto:team@opensafely.org).

--- a/docs/how-to-get-help.md
+++ b/docs/how-to-get-help.md
@@ -1,7 +1,6 @@
 ## Slack
 
 You will be invited to join the Bennett Institute's workspace during the co-pilot programme.
-If you're outside the co-pilot programme,
 then your second port of call should be to ask your question in any channel to which you have access.
 
 You may wish to direct your question to the **tech support team**.

--- a/docs/how-to-get-help.md
+++ b/docs/how-to-get-help.md
@@ -1,7 +1,7 @@
 ## Slack
 
 You will be invited to join the Bennett Institute's workspace during the co-pilot programme.
-then your second port of call should be to ask your question in any channel to which you have access.
+Please feel free to ask questions in any channel to which you have access.
 
 You may wish to direct your question to the **tech support team**.
 To do so, include the string `tech-support` in your question

--- a/docs/outputs/sdc.md
+++ b/docs/outputs/sdc.md
@@ -170,7 +170,7 @@ There may be cases where you have run an analysis and results have been released
 If you are likely to release data multiple times, e.g. for initial discussion with collaborators, use rounding of outputs initially and/or a threshold substantially higher than 5 for suppressing low numbers.
 
 ### Requesting exceptions
-The principles outlined above balance minimising the risk of re-identification of individuals with the requirements of researchers. These principles are designed to enable us to provide an efficient output checking service. In rare cases an exception to our output checking rules may be justified. If you wish to request an exception please make informal enquiries to the output checking lead, Colm Andrews (colm.andrews@phc.ox.ac.uk). Applications can then be submitted to datarelease@opensafely.org 
+The principles outlined above balance minimising the risk of re-identification of individuals with the requirements of researchers. These principles are designed to enable us to provide an efficient output checking service. In rare cases an exception to our output checking rules may be justified. If you wish to request an exception please make informal enquiries to the output checking lead, Colm Andrews (colm.andrews@phc.ox.ac.uk). Applications can then be submitted to datarelease@opensafely.org
 
 ### Further reading
 
@@ -187,5 +187,3 @@ There are also resources for extended guidance for analysis methods commonly use
     [Ritchie, Felix. Output-based disclosure control for regressions” (2012).](https://www2.uwe.ac.uk/faculties/BBS/BUS/Research/economics2012/1209.pdf)
 * Survival analysis:
     [O’Keefe, C. M., Sparks, R. S., McAullay, D. & Loong, B. Confidentialising Survival Analysis Output in a Remote Data Access System. J. Priv. Confidentiality 4, (2012)](https://journalprivacyconfidentiality.org/index.php/jpc/article/view/614)
-
-There is also a disclosure control section in our [Q&A forum](https://github.com/opensafely/documentation/discussions/categories/disclosure-control) where you can ask any questions you may have.


### PR DESCRIPTION
Remove all references to Q&A forum in our docs, as it isn't used and a lot of the info in it is out-of-date (e.g. cohortextractor). 