### PR TITLE
Update the process for transferring repo to opensafely

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -89,9 +89,9 @@ You may want to start work on a project before approval by [creating a repositor
 
 ### How to transfer an existing repository to the opensafely organization
 
-To transfer a repository from your personal GitHub account to the OpenSAFELY organisation, contact [Tech Support](how-to-get-help.md/#slack) to initiate the transfer.
+To transfer a repository from your personal GitHub account to the OpenSAFELY organisation, contact [Tech Support](how-to-get-help.md/#slack) to request a repository transfer.
 
-Tech Support will notify you once the transfer has been completed. You will also be able to see the repository listed in the [`opensafely` organisation](https://github.com/orgs/opensafely/repositories) once transferred.
+Tech Support will guide you through the transfer process and notify you once the repository has been transferred. You will also be able to see the repository listed in the [`opensafely` organisation](https://github.com/orgs/opensafely/repositories) once transferred.
 
 The settings of any transferred repositories will be updated to match the [default `opensafely` repository settings](#default-repository-settings-in-the-github-opensafely-organisation).
 

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -89,11 +89,9 @@ You may want to start work on a project before approval by [creating a repositor
 
 ### How to transfer an existing repository to the opensafely organization
 
-To transfer a repository from your personal GitHub account to the OpenSAFELY organisation:
+To transfer a repository from your personal GitHub account to the OpenSAFELY organisation, contact [Tech Support](how-to-get-help.md/#slack) to initiate the transfer.
 
-1. Follow [GitHub's instructions](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository#transferring-a-repository-owned-by-your-personal-account) to initiate a transfer.
-2. Contact [Tech Support](how-to-get-help.md/#slack) to request approval for the repository transfer.
-3. Tech Support will notify you once the transfer has been completed. You will also be able to see the repository listed in the [`opensafely` organisation](https://github.com/orgs/opensafely/repositories) once transferred.
+Tech Support will notify you once the transfer has been completed. You will also be able to see the repository listed in the [`opensafely` organisation](https://github.com/orgs/opensafely/repositories) once transferred.
 
 The settings of any transferred repositories will be updated to match the [default `opensafely` repository settings](#default-repository-settings-in-the-github-opensafely-organisation).
 


### PR DESCRIPTION
A change was made recently in how we manage GitHub research repositories. Tech-support is now responsible to transfer a user's github repository to the opensafely organisation. The tech support
[docs](https://github.com/ebmdatalab/team-manual/pull/1344) are already updated. This PR updates the main doc too so that user routes their request to tech-support instead of trying to transfer it themselves (they get  permissions issues when they try to transfer their repo to opensafely organisation).