### PR TITLE
Remove gitHubToken from deployment step

### DIFF
--- a/.github/workflows/pages-deployment.yml
+++ b/.github/workflows/pages-deployment.yml
@@ -43,4 +43,3 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_DIRECT_UPLOAD_API_TOKEN }}
           command: pages deploy site --project-name=opensafely-docs
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As per the Cloudflare Docs[^1]:

> Optional: Enable this if you want to have GitHub Deployments
> triggered

We do not use GitHub Deployments, so do not need this enabled

Part of #2026

[^1]: https://github.com/cloudflare/wrangler-action/blob/84c72882ef1dacec6f70cdca9666d4625494e009/README.md#deploy-your-pages-site-production--preview