### PR TITLE
Update Plan S compliance information

### DIFF
--- a/docs/plan-s.md
+++ b/docs/plan-s.md
@@ -1,6 +1,6 @@
 ### Academic Journal Destination: Plan S and OpenSAFELY
 
-[Plan S](https://www.coalition-s.org/) is an initiative for Open Access publishing. Plan S requires that scientific publications that result from research funded by public grants must be published in compliant Open Access journals or platforms. Wellcome are a core funder of the OpenSAFELY platform, therefore we ask that academic outputs comply with Wellcome's Plan S requirements for journal publication. It is likely that teams will be required to comply with this for other reasons, such as receiving funding from NIHR / UKRI. For further details see [openaccess.ox.ac.uk/wellcome](https://openaccess.ox.ac.uk/wellcome).
+[Plan S](https://www.coalition-s.org/) is an initiative for Open Access publishing. Plan S requires that scientific publications that result from research funded by public grants must be published in compliant Open Access journals or platforms. Wellcome are a core funder of the OpenSAFELY platform, therefore we ask that academic outputs comply with Wellcome's Plan S requirements for journal publication. It is likely that teams will be required to comply with this for other reasons, such as receiving funding from NIHR / UKRI. 
 
 ### How do I check journal open access compliance?
 


### PR DESCRIPTION
Removed a link to Wellcome's Open Access details from the Plan S section.