### PR TITLE
Use requirements.prod.in for prod constraint

### DIFF
--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -1,4 +1,4 @@
---constraint requirements.prod.txt
+--constraint requirements.prod.in
 
 # Additional dev requirements
 # To generate a requirements file that includes both prod and dev requirements, run:

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -16,7 +16,6 @@ click==8.2.1 \
     --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
     --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
     # via
-    #   -c requirements.prod.txt
     #   pip-tools
 distlib==0.4.3 \
     --hash=sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b \
@@ -40,7 +39,6 @@ packaging==24.2 \
     --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \
     --hash=sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f
     # via
-    #   -c requirements.prod.txt
     #   build
     #   wheel
 pip-tools==7.6.0 \
@@ -51,7 +49,6 @@ platformdirs==4.3.6 \
     --hash=sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907 \
     --hash=sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb
     # via
-    #   -c requirements.prod.txt
     #   virtualenv
 pre-commit==4.6.1 \
     --hash=sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421 \
@@ -124,7 +121,6 @@ pyyaml==6.0.2 \
     --hash=sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12 \
     --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4
     # via
-    #   -c requirements.prod.txt
     #   pre-commit
 ruff==0.16.1 \
     --hash=sha256:07bf434b1c95f4e093be4532068ef4fcf00924eb2ade8796075980902d6fd54a \


### PR DESCRIPTION
This seems to fix dependency graph failure in other repos so trying it out for documentation.

Example for reports: https://github.com/opensafely-core/reports/pull/1150
