### PR TITLE
Use `-c` instead of `--constraint` for dependabot

### DIFF
--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -1,4 +1,4 @@
---constraint requirements.prod.in
+-c requirements.prod.in
 
 # Additional dev requirements
 # To generate a requirements file that includes both prod and dev requirements, run:


### PR DESCRIPTION
The previous [commit](https://github.com/opensafely/documentation/commit/8afdf9848748153ecb22e58e60f1d57a881583c3) updated the constraint from `requirements.prod.txt` to `requirements.prod.in`, but retained the long-form `--constraint` option.

Dependabot recognises the short-form -c option when finding referenced files. As a result, it did not copy requirements.prod.in into its temporary directory and the update-pip-graph job continued to fail.

Related dependabot issue - https://github.com/dependabot/dependabot-core/pull/15581