### PR TITLE
 Switch from Dependabot to update-dependencies action for Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,6 @@
 version: 2
 
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "08:00"
-      timezone: "Europe/London"
-    cooldown:
-      default-days: 7
-    groups:
-      production-dependencies:
-        dependency-type: "production"
-      development-dependencies:
-        dependency-type: "development"
-    allow:
-      - dependency-type: "all"
-    ignore:
-      # mkdocs has a file reload bug with newer click versions,
-      # so pin until this is resolved:
-      # https://github.com/mkdocs/mkdocs/issues/4032
-      - dependency-name: "click"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/update-python-dependencies.yml
+++ b/.github/workflows/update-python-dependencies.yml
@@ -1,0 +1,32 @@
+name: Update Python dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  "16 7 * * MON"
+
+permissions:
+  contents: read
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - uses: opensafely-core/setup-action@d9171097dd0d37bdb7bed58f701eb03ff317ed17 # v1.7.0
+      with:
+        install-just: true
+
+    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      id: generate-token
+      with:
+        app-id: 1031449  # opensafely-core Create PR app
+        private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
+
+    - uses: bennettoxford/update-dependencies-action@b77a22bcfe1d06020d908e64c9828fe944da3a5e
+      id: update
+      with:
+        token: ${{ steps.generate-token.outputs.token }}

--- a/justfile
+++ b/justfile
@@ -136,3 +136,6 @@ wordcount: build
     #!/usr/bin/env bash
     set -euo pipefail
     find site/ -name '*.html' -exec python scripts/wordcount.py {} + | awk '{sum += $1} END {print "Total words in documentation:", sum}'
+
+# Update prod and dev dependencies
+update-dependencies: (upgrade 'prod') (upgrade 'dev')


### PR DESCRIPTION
Closes https://github.com/opensafely/documentation/issues/2018

Ran `just update-dependencies` locally and it updated dependencies in requirements.prod.txt and requirements.dev.txt

Ran different workflows using workflow_dispatch on this branch and they passed. Can't run dependabot updates from a branch.