### PR TITLE
Update docs regarding forking on private repos

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -19,6 +19,8 @@ Contact [Tech Support](how-to-get-help.md/#slack) to request that your repositor
 
 If your request is approved, Tech Support will make your repository private and you will be notified once this has been completed.
 
+If your OpenSAFELY repository is made private, other users will not be able to fork the repository. Instead they can make a copy ("clone") of it (see the [GitHub documentation on cloning a repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository#about-cloning-a-repository) for more information on this).
+
 Private repositories will be made public after 12 months. Ahead of that, you can make a new request to extend the private visibility period for another 12 months.
 
 !!! info


### PR DESCRIPTION
Following a [tech support query](https://bennettoxford.slack.com/archives/C33TWNQ1J/p1787155085506709?thread_ts=1787138329.248319&cid=C33TWNQ1J), this PR updates the OpenSAFELY documentation to clarify that private repositories cannot be forked, and explains that users can clone the repository instead.

Note to reviewer: I'm unsure whether this is an official policy or rule that we want to enforce and make clear to users. It's stated in the Manual management of research repos policy proposal, in the [Notes](https://docs.google.com/document/d/1nxM1f0-hn_n1kBiXxWsM5athdMCoTF7ZBWTfeaQ-TLY/edit?tab=t.0#heading=h.w3sr2ju6x6nz) section, but not in the [NHS OpenSAFELY Management of Research Repositories Policy](https://docs.google.com/document/d/1f1_xYtBqu99I66TuhjfvbyW0VwsgZW1x2DKmh8WYvu0/edit?tab=t.0) (Internal).

